### PR TITLE
tctm: srs3_tc: Remove spaces from attribute name

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -46,3 +46,15 @@ jobs:
         with:
           name: artifacts-${{ matrix.python-version }}
           path: builddir
+
+      - name: Install xmllint
+        run: |
+          sudo apt-get install libxml2-utils
+
+      - name: Validate against XSD
+        run: |
+          xmllint --noout --schema xsd/xtce-v1.2.xsd builddir/mdb/scsat1_header.xml
+          xmllint --noout --schema xsd/xtce-v1.2.xsd builddir/mdb/scsat1_main.xml
+          xmllint --noout --schema xsd/xtce-v1.2.xsd builddir/mdb/scsat1_adcs.xml
+          xmllint --noout --schema xsd/xtce-v1.2.xsd builddir/mdb/scsat1_eps.xml
+          xmllint --noout --schema xsd/xtce-v1.2.xsd builddir/mdb/scsat1_srs3.xml

--- a/py/tctm/srs3_tc.yaml
+++ b/py/tctm/srs3_tc.yaml
@@ -17,31 +17,31 @@ csp_commands:
 default_commands:
   - name: srs3_command
     commands:
-      - name: "SRS-3 telemetry data"
+      - name: "srs3_telemetry_data"
         port: 19
         arguments:
           - name: command_id
             type: binary
             val: 0101C8000480
-      - name: "SRS-3 TX group data"
+      - name: "srs3_tx_group_data"
         port: 19
         arguments:
           - name: command_id
             type: binary
             val: 0101C8000180
-      - name: "SRS-3 RX group data"
-        port: 19 
+      - name: "srs3_rx_group_data"
+        port: 19
         arguments:
           - name: command_id
             type: binary
             val: 0101C8000200
-      - name: "SRS-3 boot count"
+      - name: "srs3_boot_count"
         port: 19
         arguments:
           - name: command_id
             type: binary
             val: 0101C800428C
-      - name: "SRS-3 WDT count"
+      - name: "srs3_wdt_count"
         port: 19
         arguments:
           - name: command_id


### PR DESCRIPTION
Remove spaces from name attributes.  This is invalid with XTCE spec v1.2.

    ❯ xmllint --noout --schema xtce-v1.2.xsd mdb/scsat1_main.xml
    mdb/scsat1_srs3.xml:1093: element BinaryArgumentType: Schemas
    validity error : Element
    '{http://www.omg.org/spec/XTCE/20180204}BinaryArgumentType',
    attribute 'name': [facet 'pattern'] The value 'SRS-3 RX group
    data__command_id' is not accepted by the pattern '[^./:\[\] ]+'.