### PR TITLE
tctm: Add CSP port number for telemetry condition

### DIFF
--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -48,6 +48,8 @@ containers:
   - name: TEMP
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 9
     parameters:
@@ -107,6 +109,8 @@ containers:
   - name: CURRENT_VOLTAGE
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 10
     parameters:
@@ -307,6 +311,8 @@ containers:
   - name: IMU
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 11
     parameters:
@@ -349,6 +355,8 @@ containers:
   - name: GNSS_HWMON
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 12
     parameters:
@@ -407,6 +415,8 @@ containers:
   - name: GNSS_BESTPOS
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 13
     parameters:
@@ -509,6 +519,8 @@ containers:
   - name: RW
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 14
     parameters:
@@ -531,6 +543,8 @@ containers:
   - name: HWTEST_RESULT
     endian: true
     conditions:
+      - name: "../csp_sport"
+        val: 10
       - name: "ADCS/telemetry_id"
         val: 15
     parameters:

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -48,6 +48,8 @@ containers:
   - name: TEMP
     endian: true
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 1    
     parameters:
@@ -118,6 +120,8 @@ containers:
   - name: CURRENT_VOLTAGE
     endian: true
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 2
     parameters:
@@ -237,6 +241,8 @@ containers:
   - name: CSP
     endian: true 
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 3
     parameters:
@@ -313,6 +319,8 @@ containers:
   - name: SUNSENSOR
     endian: true
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 4
     parameters:
@@ -375,6 +383,8 @@ containers:
   - name: MAGNET_METER
     endian: true
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 5
     parameters:
@@ -427,6 +437,8 @@ containers:
   - name: DSTRX3
     endian: true 
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 6
     parameters:
@@ -467,6 +479,8 @@ containers:
   - name: HWTEST_RESULT
     endian: true
     conditions:
+      - name: "../csp_dport"
+        val: 10
       - name: "MAIN/telemetry-id"
         val: 7
     parameters:


### PR DESCRIPTION
Currently, we are using only the 1-byte telemetry ID located after the CSP header to differentiate between telemetry from MAIN and ADCS. However, if we start the satctrl used for SRS-3 with the same CSP ID as MAIN or ADCS, there is a risk of misjudgment if, by coincidence, the same telemetry ID matches the data received in Yamcs. Therefore, this commit adds the CSP port number to help differentiate the telemetry for MAIN and ADCS.