### PR TITLE
py,tctm: Fix bit size for string parameter

### DIFF
--- a/py/create_xtce.py
+++ b/py/create_xtce.py
@@ -67,7 +67,7 @@ def set_encoding(param, endian):
         )
     elif param_type == "string":
         enc = StringEncoding(
-            bits=param.get("bit", 32)*8,
+            bits=param.get("bit", 256),
         )
     elif param_type == "binary":
         enc = BinaryEncoding(

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -454,10 +454,10 @@ containers:
         bit: 32
       - name: "BESTPOS_SOL_STAT"
         type: string
-        bit: 24
+        bit: 192
       - name: "BESTPOS_POS_TYPE"
         type: string
-        bit: 24
+        bit: 192
       - name: "BESTPOS_LAT_DEG"
         type: float
         bit: 32
@@ -472,7 +472,7 @@ containers:
         bit: 32
       - name: "BESTPOS_DATUM_ID"
         type: string
-        bit: 16
+        bit: 128
       - name: "BESTPOS_LAT_M"
         type: float
         bit: 32
@@ -484,7 +484,7 @@ containers:
         bit: 32
       - name: "BESTPOS_STN_ID"
         type: string
-        bit: 12
+        bit: 96
       - name: "BESTPOS_DIFF_AGE"
         type: float
         bit: 32
@@ -559,10 +559,10 @@ containers:
         bit: 32
       - name: "HWTEST_VERSION"
         type: string
-        bit: 32
+        bit: 256
       - name: "HWTEST_LAST_CMD"
         type: string
-        bit: 32
+        bit: 256
 
 # Command Reply Telemetry
   - name: POWER_CONTROL_CMD_REPLY

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -492,10 +492,10 @@ containers:
         bit: 32
       - name: "HWTEST_VERSION"
         type: string
-        bit: 32
+        bit: 256
       - name: "HWTEST_LAST_CMD"
         type: string
-        bit: 32
+        bit: 256
 
 # Command Reply Telemetry
   - name: POWER_CONTROL_CMD_REPLY


### PR DESCRIPTION
The current size of the string parameter can be set with the name `bi`t, but since it is multiplied by 8 in the conversion script, it is effectively assumed to be set in bytes. This commit fixes it to allow setting in bits.