### PR TITLE
tctm: Add erase command for Config NOR flash

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -57,3 +57,27 @@ default_commands:
           - name: "target"
             type: string
             bit: 512
+      - name: "ERASE_CFG_FLASH_CMD"
+        port: 14
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0
+          - name: "cfg_bank"
+            type: enum
+            choices:
+              - [0, "CFG_MEM_0"]
+              - [1, "CFG_MEM_1"]
+          - name: "partition_id"
+            type: enum
+            choices:
+              - [0, "GOLDEN_BIT"]
+              - [1, "GOLDEN_FSW"]
+              - [2, "UPDATE_BIT"]
+              - [3, "UPDATE_FSW"]
+          - name: "offset"
+            bit: 32
+            val: 0
+          - name: "size"
+            bit: 32
+            val: 0

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -605,3 +605,25 @@ containers:
       - name: "ERROR_CODE_OF_REMOVE_FILE"
         signed: true
         bit: 32
+  - name: FLASH_CMD_UNKOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "ADCS/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN"
+        signed: true
+        bit: 32
+  - name: ERASE_CFG_FLASH_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "ADCS/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
+        signed: true
+        bit: 32

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -60,3 +60,27 @@ default_commands:
           - name: "target"
             type: string
             bit: 512
+      - name: "ERASE_CFG_FLASH_CMD"
+        port: 14
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0
+          - name: "cfg_bank"
+            type: enum
+            choices:
+              - [0, "CFG_MEM_0"]
+              - [1, "CFG_MEM_1"]
+          - name: "partition_id"
+            type: enum
+            choices:
+              - [0, "GOLDEN_BIT"]
+              - [1, "GOLDEN_FSW"]
+              - [2, "UPDATE_BIT"]
+              - [3, "UPDATE_FSW"]
+          - name: "offset"
+            bit: 32
+            val: 0
+          - name: "size"
+            bit: 32
+            val: 0

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -538,3 +538,25 @@ containers:
       - name: "ERROR_CODE_OF_REMOVE_FILE"
         signed: true
         bit: 32
+  - name: FLASH_CMD_UNKOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "MAIN/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN"
+        signed: true
+        bit: 32
+  - name: ERASE_CFG_FLASH_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "MAIN/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
+        signed: true
+        bit: 32


### PR DESCRIPTION
This commit add the erase command for Config NOR flash and adds the reply telemetry.