### PR TITLE
tctm: Add power cycle command for MAIN/ADCS

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -39,6 +39,12 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
+      - name: "POWER_CYCLE_CMD"
+        port: 12
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
       - name: "GET_FILE_INFO_CMD"
         port: 13
         arguments:

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -576,6 +576,28 @@ containers:
       - name: "ERROR_CODE_OF_POWER_CONTROL"
         signed: true
         bit: 32
+  - name: POWER_CYCLE_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 12
+      - name: "ADCS/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_POWER_CYCLE"
+        signed: true
+        bit: 32
+  - name: PWRCTR_CMD_UNKOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 12
+      - name: "ADCS/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN_PWRCTRL"
+        signed: true
+        bit: 32
   - name: FILE_INFO_CMD_REPLY
     endian: true
     conditions:

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -42,6 +42,12 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
+      - name: "POWER_CYCLE_CMD"
+        port: 12
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
       - name: "GET_FILE_INFO_CMD"
         port: 13
         arguments:

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -509,6 +509,28 @@ containers:
       - name: "ERROR_CODE_OF_POWER_CONTROL"
         signed: true
         bit: 32
+  - name: POWER_CYCLE_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 12
+      - name: "MAIN/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_POWER_CYCLE"
+        signed: true
+        bit: 32
+  - name: PWRCTR_CMD_UNKOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 12
+      - name: "MAIN/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN_PWRCTRL"
+        signed: true
+        bit: 32
   - name: FILE_INFO_CMD_REPLY
     endian: true
     conditions:


### PR DESCRIPTION
This command adds a power cycle command for the MAIN/ADCS board and reply telemetry. The power cycle is requested to the TRCH via the FPGA.