### PR TITLE
tctm: Add one shot System HK command

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -87,3 +87,9 @@ default_commands:
           - name: "size"
             bit: 32
             val: 0
+      - name: "GET_SYSTEM_HK"
+        port: 15
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -90,3 +90,9 @@ default_commands:
           - name: "size"
             bit: 32
             val: 0
+      - name: "GET_SYSTEM_HK"
+        port: 15
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0


### PR DESCRIPTION
This commit adds a command to obtain System HK telemetry from the MAIN and ADCS boards in one shot.