### PR TITLE
tctm: Add clear boot count command

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -93,3 +93,9 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+      - name: "CLEAR_BOOT_COUNT"
+        port: 16
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -899,3 +899,25 @@ containers:
       - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
         signed: true
         bit: 32
+  - name: CLEAR_BOOT_COUNT_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "ADCS/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_CLEAR_BOOT_COUNT"
+        signed: true
+        bit: 32
+  - name: CLEAR_BOOT_COUNT_CMD_UNKNOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "ADCS/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN_CLEAR_BOOT_COUNT"
+        signed: true
+        bit: 32

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -96,3 +96,9 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+      - name: "CLEAR_BOOT_COUNT"
+        port: 16
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -883,3 +883,25 @@ containers:
       - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
         signed: true
         bit: 32
+  - name: CLEAR_BOOT_COUNT_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "MAIN/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_CLEAR_BOOT_COUNT"
+        signed: true
+        bit: 32
+  - name: CLEAR_BOOT_COUNT_CMD_UNKNOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "MAIN/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_UNKNOWN_CLEAR_BOOT_COUNT"
+        signed: true
+        bit: 32


### PR DESCRIPTION
This commit adds a command to clear the boot count stored in FRAM. This command is primarily intended to be executed during testing and right before launch. In addition, it also adds telemetry for reply.