### PR TITLE
Add CRC32 option to FILE INFO command

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -51,6 +51,11 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+          - name: "crc32_calc"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "target"
             type: string
             bit: 512

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -863,6 +863,8 @@ containers:
         bit: 8
       - name: "FILE_SIZE"
         bit: 32
+      - name: "CRC32"
+        bit: 32
       - name: "FILE_NAME"
         type: string
         bit: 512

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -54,6 +54,11 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+          - name: "crc32_calc"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "target"
             type: string
             bit: 512

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -847,6 +847,8 @@ containers:
         bit: 8
       - name: "FILE_SIZE"
         bit: 32
+      - name: "CRC32"
+        bit: 32
       - name: "FILE_NAME"
         type: string
         bit: 512


### PR DESCRIPTION
This commit adds an option to the File info command to calculate the CRC32 value. Since CRC32 calculation may take a long time for larger files, this update enables users to toggle the option on or off when executing the command.