### PR TITLE
tctm: Add erase Data NOR command

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -86,6 +86,16 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
+      - name: "ERASE_DATA_FLASH_CMD"
+        port: 14
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "partition_id"
+            type: enum
+            choices:
+              - [4, "STORAGE"]
           - name: "offset"
             bit: 32
             val: 0

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -901,6 +901,17 @@ containers:
       - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
         signed: true
         bit: 32
+  - name: ERASE_DATA_FLASH_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "ADCS/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_ERASE_DATA_FLASH"
+        signed: true
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_REPLY
     endian: true
     conditions:

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -95,6 +95,16 @@ default_commands:
           - name: "size"
             bit: 32
             val: 0
+      - name: "ERASE_DATA_FLASH_CMD"
+        port: 14
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "partition_id"
+            type: enum
+            choices:
+              - [4, "STORAGE"]
       - name: "GET_SYSTEM_HK"
         port: 15
         arguments:

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -885,6 +885,17 @@ containers:
       - name: "ERROR_CODE_OF_ERASE_CFG_FLASH"
         signed: true
         bit: 32
+  - name: ERASE_DATA_FLASH_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "MAIN/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_ERASE_DATA_FLASH"
+        signed: true
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_REPLY
     endian: true
     conditions:


### PR DESCRIPTION
This commit adds an erase command handler for the NOR flash partition used for data storage.