### PR TITLE
Rename parameter "+/-" to "_P/_N"

### DIFF
--- a/py/tctm/eps_tm.yaml
+++ b/py/tctm/eps_tm.yaml
@@ -114,18 +114,18 @@ containers:
         bit: 32
       - name: "COUNTER_WDT"
         bit: 32
-      - name: "MPPT_CONV_VOLT_X+"
-      - name: "MPPT_CONV_VOLT_Y+"
-      - name: "MPPT_CONV_VOLT_X-"
-      - name: "MPPT_CONV_VOLT_Y-"
+      - name: "MPPT_CONV_VOLT_X_P"
+      - name: "MPPT_CONV_VOLT_Y_P"
+      - name: "MPPT_CONV_VOLT_X_M"
+      - name: "MPPT_CONV_VOLT_Y_M"
       - name: "CURR_SOLAR_PANELS_1"
-      - name: "CURR_SOLAR_PANELS_X+"
+      - name: "CURR_SOLAR_PANELS_X_P"
       - name: "CURR_SOLAR_PANELS_3"
-      - name: "CURR_SOLAR_PANELS_Y+"
+      - name: "CURR_SOLAR_PANELS_Y_P"
       - name: "CURR_SOLAR_PANELS_5"
-      - name: "CURR_SOLAR_PANELS_X-"
+      - name: "CURR_SOLAR_PANELS_X_M"
       - name: "CURR_SOLAR_PANELS_7"
-      - name: "CURR_SOLAR_PANELS_Y-"
+      - name: "CURR_SOLAR_PANELS_Y_M"
       - name: "BATT_VOLT"
       - name: "CURR_SOLAR"
       - name: "CURR_BATT_IN"
@@ -327,16 +327,16 @@ containers:
         bit: 8
       - name: "OUTPUT_FAULT_COUNT_18"
         bit: 8
-      - name: "TEMP_MPPT_X+"
+      - name: "TEMP_MPPT_X_P"
         bit: 8
         signed: true
-      - name: "TEMP_MPPT_Y+"
+      - name: "TEMP_MPPT_Y_P"
         bit: 8
         signed: true
-      - name: "TEMP_MPPT_X-"
+      - name: "TEMP_MPPT_X_M"
         bit: 8
         signed: true
-      - name: "TEMP_MPPT_Y-"
+      - name: "TEMP_MPPT_Y_M"
         bit: 8
         signed: true
       - name: "TEMP_CONV_3V3"

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -131,28 +131,28 @@ containers:
       - name: "IO_BOARD_TEMP_2"
         type: float
         bit: 32
-      - name: "TEMP_X+_SENSOR_STATUS"
+      - name: "TEMP_X_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_X+"
+      - name: "TEMP_X_P"
         type: float
         bit: 32
-      - name: "TEMP_X-_SENSOR_STATUS"
+      - name: "TEMP_X_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_X-"
+      - name: "TEMP_X_M"
         type: float
         bit: 32
-      - name: "TEMP_Y+_SENSOR_STATUS"
+      - name: "TEMP_Y_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_Y+"
+      - name: "TEMP_Y_P"
         type: float
         bit: 32
-      - name: "TEMP_Y-_SENSOR_STATUS"
+      - name: "TEMP_Y_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_Y-"
+      - name: "TEMP_Y_M"
         type: float
         bit: 32
       - name: "OBC_MODULE_1V0_CURR_SENSOR_STATUS"
@@ -281,68 +281,68 @@ containers:
       - name: "IO_BOARD_3V3_VOLT"
         endian: true
         bit: 32
-      - name: "MAGNETOMETER_Y+_SENSOR_STATUS"
+      - name: "MAGNETOMETER_Y_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "MAGNETOMETER_Y+_X_OUT"
+      - name: "MAGNETOMETER_Y_P_X_OUT"
         bit: 16
-      - name: "MAGNETOMETER_Y+_Y_OUT"
+      - name: "MAGNETOMETER_Y_P_Y_OUT"
         bit: 16
-      - name: "MAGNETOMETER_Y+_Z_OUT"
+      - name: "MAGNETOMETER_Y_P_Z_OUT"
         bit: 16
-      - name: "MAGNETOMETER_Y-_SENSOR_STATUS"
+      - name: "MAGNETOMETER_Y_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "MAGNETOMETER_Y-_X_OUT"
+      - name: "MAGNETOMETER_Y_M_X_OUT"
         bit: 16
-      - name: "MAGNETOMETER_Y-_Y_OUT"
+      - name: "MAGNETOMETER_Y_M_Y_OUT"
         bit: 16
-      - name: "MAGNETOMETER_Y-_Z_OUT"
+      - name: "MAGNETOMETER_Y_M_Z_OUT"
         bit: 16
-      - name: "TEMP_ON_MAGNETOMETER_Y+_SENSOR_STATUS"
+      - name: "TEMP_ON_MAGNETOMETER_Y_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_ON_MAGNETOMETER_Y+"
+      - name: "TEMP_ON_MAGNETOMETER_Y_P"
         type: float
         bit: 32
-      - name: "TEMP_ON_MAGNETOMETER_Y-_SENSOR_STATUS"
+      - name: "TEMP_ON_MAGNETOMETER_Y_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_ON_MAGNETOMETER_Y-"
+      - name: "TEMP_ON_MAGNETOMETER_Y_M"
         type: float
         bit: 32
-      - name: "SUN_SENSOR_Y+_SENSOR_STATUS"
+      - name: "SUN_SENSOR_Y_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "SUN_SENSOR_Y+_A"
+      - name: "SUN_SENSOR_Y_P_A"
         bit: 16
-      - name: "SUN_SENSOR_Y+_B"
+      - name: "SUN_SENSOR_Y_P_B"
         bit: 16
-      - name: "SUN_SENSOR_Y+_C"
+      - name: "SUN_SENSOR_Y_P_C"
         bit: 16
-      - name: "SUN_SENSOR_Y+_D"
+      - name: "SUN_SENSOR_Y_P_D"
         bit: 16
-      - name: "SUN_SENSOR_Y-_SENSOR_STATUS"
+      - name: "SUN_SENSOR_Y_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "SUN_SENSOR_Y-_A"
+      - name: "SUN_SENSOR_Y_M_A"
         bit: 16
-      - name: "SUN_SENSOR_Y-_B"
+      - name: "SUN_SENSOR_Y_M_B"
         bit: 16
-      - name: "SUN_SENSOR_Y-_C"
+      - name: "SUN_SENSOR_Y_M_C"
         bit: 16
-      - name: "SUN_SENSOR_Y-_D"
+      - name: "SUN_SENSOR_Y_M_D"
         bit: 16
-      - name: "TEMP_ON_SUN_SENSOR_Y+_SENSOR_STATUS"
+      - name: "TEMP_ON_SUN_SENSOR_Y_P_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_ON_SUN_SENSOR_Y+"
+      - name: "TEMP_ON_SUN_SENSOR_Y_P"
         type: float
         bit: 32
-      - name: "TEMP_ON_SUN_SENSOR_Y-_SENSOR_STATUS"
+      - name: "TEMP_ON_SUN_SENSOR_Y_M_SENSOR_STATUS"
         bit: 8
         signed: true
-      - name: "TEMP_ON_SUN_SENSOR_Y-"
+      - name: "TEMP_ON_SUN_SENSOR_Y_M"
         type: float
         bit: 32
 


### PR DESCRIPTION
Since there are cases where symbol characters cannot be used by the Yamcs parser, they have been unified to _P/_M.