### PR TITLE
tctm: Add SRS-3 GS WDT Reset Request

### DIFF
--- a/py/tctm/srs3_tc.yaml
+++ b/py/tctm/srs3_tc.yaml
@@ -53,3 +53,10 @@ default_commands:
           - name: command_id
             type: binary
             val: 0101C8004290
+      - name: "REQ_RESET_GWDT"
+        port: 19
+        arguments:
+          - name: command_id
+            type: binary
+            bit: 72
+            val: 0B01004291BB5990C1


### PR DESCRIPTION
Added request packet for Reset of SRS-3 GS Watchdog Timer. However, since reply packets cannot be identified at present, they are displayed as srs3_header.