### PR TITLE
tctm: Fix parameter for ADCS ERASE_CFG_FLASH_CMD

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -153,6 +153,12 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
+          - name: "offset"
+            bit: 32
+            val: 0
+          - name: "size"
+            bit: 32
+            val: 0
       - name: "ERASE_DATA_FLASH_CMD"
         port: 14
         arguments:


### PR DESCRIPTION
Fix the issue with the ADCS board's ERASE_CFG_FLASH_CMD as it is missing parameters.