### PR TITLE
tctm: Add get temperature command for Zero

### DIFF
--- a/py/tctm/zero_tc.yaml
+++ b/py/tctm/zero_tc.yaml
@@ -13,3 +13,13 @@ csp_commands:
         port: 5
       - name: "Sysup_time"
         port: 6
+
+default_commands:
+  - name: zero_command
+    commands:
+      - name: "GET_TEMP"
+        port: 11
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0

--- a/py/tctm/zero_tm.yaml
+++ b/py/tctm/zero_tm.yaml
@@ -4,6 +4,11 @@ headers:
     conditions:
       - name: "../csp_src"
         val: ZERO
+  - name: "payload_container"
+    base: "common_container"
+    parameters:
+      - name: "telemetry_id"
+        bit: 8
 
 containers:
 # csp common reply
@@ -38,3 +43,15 @@ containers:
     parameters:
       - name: "Sysup_time"
         bit: 32
+
+# Zero
+  - name: TEMP
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 11
+      - name: "ZERO/telemetry_id"
+        val: 0
+    parameters:
+      - name: "TEMP_RAW"
+        bit: 16


### PR DESCRIPTION
Adds a command to getting to the temperature of the Payload board via an I2C sensor connected to the Zero. However, the telemetry value in the response is the 16-bit raw data from the sensor (TMP175AQDGKRQ1).