### PR TITLE
tctm: Fix endian for ERASE_CFG_FLASH_CMD

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -137,6 +137,7 @@ default_commands:
             bit: 32
       - name: "ERASE_CFG_FLASH_CMD"
         port: 14
+        endian: true
         arguments:
           - name: "command_id"
             bit: 8

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -140,6 +140,7 @@ default_commands:
             bit: 32
       - name: "ERASE_CFG_FLASH_CMD"
         port: 14
+        endian: true
         arguments:
           - name: "command_id"
             bit: 8


### PR DESCRIPTION
Fixes the endian to little for ERASE_CFG_FLASH_CMD on MAIN/ADCS.