### PR TITLE
tctm: Remove VDD 12V CV for ADCS System HK

### DIFF
--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -257,42 +257,6 @@ containers:
       - name: "ADCS_BOARD_3V3_DRV_VOLT"
         endian: true
         bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVX_CURR_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVX_CURR"
-        type: float
-        bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVX_VOLT_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVX_VOLT"
-        type: float
-        bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVY_CURR_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVY_CURR"
-        type: float
-        bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVY_VOLT_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVY_VOLT"
-        type: float
-        bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVZ_CURR_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVZ_CURR"
-        type: float
-        bit: 32
-      - name: "ADCS_BOARD_VDD_12V_DRVZ_VOLT_SENSOR_STATUS"
-        bit: 8
-        signed: true
-      - name: "ADCS_BOARD_VDD_12V_DRVZ_VOLT"
-        type: float
-        bit: 32
 
 # Command reply
   - name: TEMP


### PR DESCRIPTION
The 12V VDD will not be used in our initial operations, and the 3V3 DRV, which serves as the power supply for the CV monitor we monitor, will also not be enabled. Therefore, it will be removed from the System HK during the initial operations.