### PR TITLE
tctm: Add shell command for Zero

### DIFF
--- a/py/tctm/zero_tc.yaml
+++ b/py/tctm/zero_tc.yaml
@@ -17,6 +17,19 @@ csp_commands:
 default_commands:
   - name: zero_command
     commands:
+      - name: "SHELL_CMD"
+        port: 10
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0
+          - name: "timeout"
+            bit: 16
+            val: 60
+          - name: shell_cmd_str
+            type: string
+            bit: 1600
       - name: "GET_TEMP"
         port: 11
         arguments:

--- a/py/tctm/zero_tm.yaml
+++ b/py/tctm/zero_tm.yaml
@@ -45,6 +45,31 @@ containers:
         bit: 32
 
 # Zero
+  - name: SHELL_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 10
+      - name: "ZERO/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_SHELL_CMD"
+        signed: true
+        bit: 32
+      - name: "SHELL_CMD_RESULT"
+        type: string
+        bit: 1920
+  - name: SHELL_CMD_UNKNOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 10
+      - name: "ZERO/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_SHELL_UNKNOWN_CMD"
+        signed: true
+        bit: 32
   - name: TEMP
     endian: true
     conditions:


### PR DESCRIPTION
Adds the shell command and reply telemetries for Zero. The commands can accept strings up to 200 bytes in length, and the command responses will be split into 240 byte segments when downlinked. However, to avoid infinite downlinking, a limit is set on the number of responses (50 responses per command).

Additionally, to account for potential command hang-ups, the timeout duration (default:60sec) can also be specified from the Ground.