### PR TITLE
py: Fix default directory name on upload script

### DIFF
--- a/py/upload_file.py
+++ b/py/upload_file.py
@@ -19,7 +19,7 @@ def main(args):
         f"/SCSAT1/{board}/UPLOAD_OPEN_CMD",
         args={
             "session_id": args.id,
-            "file_name": f"/{target_dir}/{path.name}",
+            "file_name": f"{target_dir}/{path.name}",
         }
     )
     print("Issued", command)


### PR DESCRIPTION
Fixes the default directory name on `upload_file.py`.