### PR TITLE
tctm: Add get version command for Zero

### DIFF
--- a/py/tctm/zero_tc.yaml
+++ b/py/tctm/zero_tc.yaml
@@ -73,3 +73,10 @@ default_commands:
             val: 4
           - name: "session_id"
             bit: 16
+      - name: "GET_VERSION"
+        port: 16
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0

--- a/py/tctm/zero_tm.yaml
+++ b/py/tctm/zero_tm.yaml
@@ -259,3 +259,28 @@ containers:
         bit: 32
       - name: "SESSION_ID_OF_UPLOAD_CLOSE"
         bit: 16
+  - name: GET_VERSION_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "ZERO/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_GET_VERSION"
+        signed: true
+        bit: 32
+      - name: "ZERO_CSPD_VERSION"
+        type: string
+        bit: 128
+  - name: SYSTEM_CMD_UNKNOWN_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "ZERO/telemetry_id"
+        val: 255
+    parameters:
+      - name: "ERROR_CODE_OF_SYSTEM_UNKNOWN_CMD"
+        signed: true
+        bit: 32


### PR DESCRIPTION
Adds the get version command for Zero. Currently, it only returns a hard-coded version string.