### PR TITLE
tctm: Add Read FPGA register command

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -229,3 +229,13 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+      - name: "READ_FPGA_REG_CMD"
+        port: 16
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "address"
+            type: binary
+            bit: 32

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -1119,6 +1119,20 @@ containers:
       - name: "ERROR_CODE_OF_CLEAR_BOOT_COUNT"
         signed: true
         bit: 32
+  - name: READ_FPGA_REG_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "ADCS/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_READ_FPGA_REG"
+        signed: true
+        bit: 32
+      - name: "REGISTER_VALUE"
+        type: binary
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_UNKNOWN_REPLY
     endian: true
     conditions:

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -209,3 +209,13 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+      - name: "READ_FPGA_REG_CMD"
+        port: 16
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "address"
+            type: binary
+            bit: 32

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -1114,6 +1114,20 @@ containers:
       - name: "ERROR_CODE_OF_CLEAR_BOOT_COUNT"
         signed: true
         bit: 32
+  - name: READ_FPGA_REG_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "MAIN/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_READ_FPGA_REG"
+        signed: true
+        bit: 32
+      - name: "REGISTER_VALUE"
+        type: binary
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_UNKNOWN_REPLY
     endian: true
     conditions:


### PR DESCRIPTION
Adds a command to read the address of an arbitrary FPGA register and reply telemetry for MAIN/ADCS board.