### PR TITLE
tctm: Add sequence number for shell cmd reply

### DIFF
--- a/py/tctm/zero_tm.yaml
+++ b/py/tctm/zero_tm.yaml
@@ -56,6 +56,8 @@ containers:
       - name: "ERROR_CODE_OF_SHELL_CMD"
         signed: true
         bit: 32
+      - name: "SEQUENCE_NUMBER"
+        bit: 32
       - name: "SHELL_CMD_RESULT"
         type: string
         bit: 1920


### PR DESCRIPTION
Shell command reply telemetry may be divided into multiple telemetries. In such cases, sequence numbers will be assigned to facilitate association.