### PR TITLE
Save CRC calculation result to FRAM

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -67,6 +67,11 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "target"
             type: string
             bit: 512
@@ -206,6 +211,11 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "offset"
             bit: 32
             val: 0

--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -151,6 +151,12 @@ default_commands:
               - [3, "UPDATE_FSW"]
           - name: "target_offset"
             bit: 32
+      - name: "GET_LAST_FILE_CRC_CMD"
+        port: 13
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 6
       - name: "ERASE_CFG_FLASH_CMD"
         port: 14
         endian: true

--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -227,6 +227,13 @@ default_commands:
             val: 0
           - name: "size"
             bit: 32
+      - name: "GET_LAST_CFG_FLASH_CRC_CMD"
+        port: 14
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 3
       - name: "GET_SYSTEM_HK"
         port: 15
         arguments:

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -1108,6 +1108,10 @@ containers:
         bit: 8
       - name: "PARTITION_ID_OF_CFG_FLASH"
         bit: 8
+      - name: "OFFSET_OF_CFG_FLASH"
+        bit: 32
+      - name: "SIZE_OF_CFG_FLASH"
+        bit: 32
       - name: "CRC32_OF_CFG_FLASH"
         bit: 32
   - name: IMU_TLM

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -1044,6 +1044,22 @@ containers:
       - name: "ERROR_CODE_OF_COPY_FILE_TO_CFG_FLASH"
         signed: true
         bit: 32
+  - name: GET_LAST_FILE_CRC_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 13
+      - name: "ADCS/telemetry_id"
+        val: 6
+    parameters:
+      - name: "ERROR_CODE_OF_LAST_FILE_CRC"
+        signed: true
+        bit: 32
+      - name: "CRC32_OF_LAST_FILE_CRC"
+        bit: 32
+      - name: "FILE_NAME_OF_LAST_FILE_CRC"
+        type: string
+        bit: 512
   - name: FLASH_CMD_UNKOWN_REPLY
     endian: true
     conditions:

--- a/py/tctm/adcs_tm.yaml
+++ b/py/tctm/adcs_tm.yaml
@@ -1098,7 +1098,7 @@ containers:
     conditions:
       - name: "../csp_sport"
         val: 14
-      - name: "MAIN/telemetry_id"
+      - name: "ADCS/telemetry_id"
         val: 2
     parameters:
       - name: "ERROR_CODE_OF_CALC_CRC_CFG_FLASH"
@@ -1113,6 +1113,27 @@ containers:
       - name: "SIZE_OF_CFG_FLASH"
         bit: 32
       - name: "CRC32_OF_CFG_FLASH"
+        bit: 32
+  - name: GET_LAST_CFG_MEMORY_CRC_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "ADCS/telemetry_id"
+        val: 3
+    parameters:
+      - name: "ERROR_CODE_OF_LAST_CFG_CRC"
+        signed: true
+        bit: 32
+      - name: "BANK_OF_LAST_CFG_CRC"
+        bit: 8
+      - name: "PARTITION_ID_OF_LAST_CFG_CRC"
+        bit: 8
+      - name: "OFFSET_OF_LAST_CFG_CRC"
+        bit: 32
+      - name: "SIZE_OF_LAST_CFG_CRC"
+        bit: 32
+      - name: "CRC32_OF_LAST_CFG_CRC"
         bit: 32
   - name: IMU_TLM
     endian: true

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -59,6 +59,11 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "target"
             type: string
             bit: 512
@@ -192,6 +197,11 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
           - name: "offset"
             bit: 32
             val: 0

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -213,6 +213,13 @@ default_commands:
             val: 0
           - name: "size"
             bit: 32
+      - name: "GET_LAST_CFG_FLASH_CRC_CMD"
+        port: 14
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 3
       - name: "GET_SYSTEM_HK"
         port: 15
         arguments:

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -143,6 +143,12 @@ default_commands:
               - [3, "UPDATE_FSW"]
           - name: "target_offset"
             bit: 32
+      - name: "GET_LAST_FILE_CRC_CMD"
+        port: 13
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 6
       - name: "ERASE_CFG_FLASH_CMD"
         port: 14
         endian: true

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -1117,6 +1117,10 @@ containers:
         bit: 8
       - name: "PARTITION_ID_OF_CFG_FLASH"
         bit: 8
+      - name: "OFFSET_OF_CFG_FLASH"
+        bit: 32
+      - name: "SIZE_OF_CFG_FLASH"
+        bit: 32
       - name: "CRC32_OF_CFG_FLASH"
         bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_REPLY

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -1123,6 +1123,27 @@ containers:
         bit: 32
       - name: "CRC32_OF_CFG_FLASH"
         bit: 32
+  - name: GET_LAST_CFG_MEMORY_CRC_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 14
+      - name: "MAIN/telemetry_id"
+        val: 3
+    parameters:
+      - name: "ERROR_CODE_OF_LAST_CFG_CRC"
+        signed: true
+        bit: 32
+      - name: "BANK_OF_LAST_CFG_CRC"
+        bit: 8
+      - name: "PARTITION_ID_OF_LAST_CFG_CRC"
+        bit: 8
+      - name: "OFFSET_OF_LAST_CFG_CRC"
+        bit: 32
+      - name: "SIZE_OF_LAST_CFG_CRC"
+        bit: 32
+      - name: "CRC32_OF_LAST_CFG_CRC"
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_REPLY
     endian: true
     conditions:

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -1053,6 +1053,22 @@ containers:
       - name: "ERROR_CODE_OF_COPY_FILE_TO_CFG_FLASH"
         signed: true
         bit: 32
+  - name: GET_LAST_FILE_CRC_CMD_REPLY
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 13
+      - name: "MAIN/telemetry_id"
+        val: 6
+    parameters:
+      - name: "ERROR_CODE_OF_LAST_FILE_CRC"
+        signed: true
+        bit: 32
+      - name: "CRC32_OF_LAST_FILE_CRC"
+        bit: 32
+      - name: "FILE_NAME_OF_LAST_FILE_CRC"
+        type: string
+        bit: 512
   - name: FLASH_CMD_UNKOWN_REPLY
     endian: true
     conditions:


### PR DESCRIPTION
Since CRC32 calculation may take time, it might not be completed within an AOS period.
To address this, an API will be added to store the CRC32 calculation result in the FRAM of MAIN/ADCS boards.
The FRAM storage is limited to a single entry, allowing only the result of the last CRC32 calculation to be saved.