### PR TITLE
tctm: Fix argument offset for Config Memory operations

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -217,16 +217,16 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
-          - name: "save_to_frame"
-            type: enum
-            choices:
-              - [0, "OFF"]
-              - [1, "ON"]
           - name: "offset"
             bit: 32
             val: 0
           - name: "size"
             bit: 32
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
       - name: "GET_LAST_CFG_FLASH_CRC_CMD"
         port: 14
         endian: true

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -203,16 +203,16 @@ default_commands:
               - [1, "GOLDEN_FSW"]
               - [2, "UPDATE_BIT"]
               - [3, "UPDATE_FSW"]
-          - name: "save_to_frame"
-            type: enum
-            choices:
-              - [0, "OFF"]
-              - [1, "ON"]
           - name: "offset"
             bit: 32
             val: 0
           - name: "size"
             bit: 32
+          - name: "save_to_frame"
+            type: enum
+            choices:
+              - [0, "OFF"]
+              - [1, "ON"]
       - name: "GET_LAST_CFG_FLASH_CRC_CMD"
         port: 14
         endian: true


### PR DESCRIPTION
Fix an issue where the command argument offset for FLASH_CFG_ERASE_CMD was incorrect with commit below.

  commit 34b3394af365d82f7a6fc6a8024efc7d0a285aeb
  Author: Takuya Sasaki <takuya.sasaki@spacecubics.com>
  Date:   Sat Nov 23 12:43:03 2024 +0900

    tctm: Add CRC save option