### PR TITLE
tctm: Fix typo of CALC_CRC_CFG_FLASH_CMD

### DIFF
--- a/py/tctm/adcs_tc.yaml
+++ b/py/tctm/adcs_tc.yaml
@@ -67,7 +67,7 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
-          - name: "save_to_frame"
+          - name: "save_to_fram"
             type: enum
             choices:
               - [0, "OFF"]
@@ -222,7 +222,7 @@ default_commands:
             val: 0
           - name: "size"
             bit: 32
-          - name: "save_to_frame"
+          - name: "save_to_fram"
             type: enum
             choices:
               - [0, "OFF"]

--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -59,7 +59,7 @@ default_commands:
             choices:
               - [0, "OFF"]
               - [1, "ON"]
-          - name: "save_to_frame"
+          - name: "save_to_fram"
             type: enum
             choices:
               - [0, "OFF"]
@@ -208,7 +208,7 @@ default_commands:
             val: 0
           - name: "size"
             bit: 32
-          - name: "save_to_frame"
+          - name: "save_to_fram"
             type: enum
             choices:
               - [0, "OFF"]


### PR DESCRIPTION
Fixes a type of CALC_CRC_CFG_FLASH_CMD.