### PR TITLE
tctm: Modify Channel Selection Display for EPS Single Output Control

### DIFF
--- a/py/tctm/eps_tc.yaml
+++ b/py/tctm/eps_tc.yaml
@@ -82,7 +82,16 @@ default_commands:
             bit: 8
             val: 0
           - name: output_nr
-            bit: 8
+            type: enum
+            choices:
+              - [1, "MAIN_OBC_A"]
+              - [2, "SRS3_A"]
+              - [3, "ADCS_A"]
+              - [4, "MAIN_OBC_B"]
+              - [5, "SRS3_B"]
+              - [6, "ADCS_B"]
+              - [8, "RW"]
+              - [9, "DSTRX3"]
           - name: state
             type: enum
             choices:


### PR DESCRIPTION
To make it easier to identify which Channel number corresponds to which power system of SC-Sat1, we changed the display format.