### PR TITLE
etc: Add new link for EPS history data

### DIFF
--- a/etc/yamcs.scsat1.yaml
+++ b/etc/yamcs.scsat1.yaml
@@ -38,6 +38,20 @@ dataLinks:
       port: 52004
       # Give the embedded simulator some time to boot up
       #initialDelay: 2000      
+    - name: tm_eps_history
+      class: org.yamcs.tctm.UdpTmDataLink
+      packetPreprocessorClassName: org.yamcs.tctm.GenericPacketPreprocessor
+      packetPreprocessorArgs:
+        errorDetection: none
+        seqCountOffset: -1
+        timestampOffset: 6
+        byteOrder: LITTLE_ENDIAN
+        timeEncoding:
+          type: FLOAT64
+          epoch: CUSTOM
+          epochUTC: "1970-01-01T00:00:00Z"
+      stream: tm_realtime
+      port: 52005
     - name: tm_dump
       class: org.yamcs.tctm.TcpTmDataLink
       stream: tm_dump


### PR DESCRIPTION
The EPS has a feature to download telemetry stored in its storage. However, since the download format is variable-length and complex, parsing it on the Yamcs side is challenging. Therefore, we use a method where the data is first parsed with a Python script and then forwarded to a dedicated port as telemetry. Additionally, the stored telemetry includes historical timestamps (64-bit float), so a configuration to associate it as a "Generation time" will also be added.