### PR TITLE
Add authentication settings

### DIFF
--- a/etc/security.yaml
+++ b/etc/security.yaml
@@ -1,0 +1,9 @@
+enabled: false
+authModules:
+  - class: org.yamcs.security.YamlAuthModule
+    args:
+      hasher: org.yamcs.security.PBKDF2PasswordHasher
+  - class: org.yamcs.security.IPAddressAuthModule
+    args:
+      address: ""
+      username: ""

--- a/etc/users.yaml
+++ b/etc/users.yaml
@@ -1,0 +1,7 @@
+admin:
+  password: ""
+  superuser: true
+
+yamcs:
+  password: ""
+  superuser: true

--- a/etc/yamcs.yaml
+++ b/etc/yamcs.yaml
@@ -2,6 +2,7 @@
 services:
   - class: org.yamcs.http.HttpServer
     args:
+      address: "localhost"
       port: 8090
       #enable the following three options to have a TLS (https) connection
       #the crt file can contain also the CA crt


### PR DESCRIPTION
This PR enables authentication for Yamcs and allows explicit configuration of the HTTP server's listen address for actual operation. However, the default settings are disabled for the testing environment, so please configure appropriate values for actual operation. .






