### PR TITLE
py: Add parameter check script

### DIFF
--- a/py/check/eps_check.yaml
+++ b/py/check/eps_check.yaml
@@ -1,0 +1,396 @@
+prefix: /SCSAT1/EPS/
+csv-dir: "./eps_check_csv"
+parameters:
+# DEPLOY_MSG
+  - name: MESSAGE
+    critical:
+      mismatch: "SC in SPACE,Mai"
+# REPLY_GENERAL_TELEMETRY
+  - name: STATUS_G
+    critical:
+      mismatch: 0
+  - name: TIMESTAMP_G
+    critical:
+      over: 1734188000
+      under: 1734177200
+  - name: UPTIME
+    critical:
+      over: 10800
+      under: 0
+  - name: BOOT_COUNT_G
+    critical:
+      mismatch: 321
+  - name: GS_WDT_TIME_LEFT
+    critical:
+      over: 108000
+      under: 97200
+  - name: COUNTER_WDT
+    critical:
+      mismatch: 0
+  - name: MPPT_CONV_VOLT_X_P
+    critical:
+      over: 6000
+      under: 0
+  - name: MPPT_CONV_VOLT_Y_P
+    critical:
+      over: 6000
+      under: 0
+  - name: MPPT_CONV_VOLT_X_M
+    critical:
+      over: 6000
+      under: 0
+  - name: MPPT_CONV_VOLT_Y_M
+    critical:
+      over: 6000
+      under: 0
+  - name: CURR_SOLAR_PANELS_X_P
+    critical:
+      over: 1030
+      under: 0
+  - name: CURR_SOLAR_PANELS_Y_P
+    critical:
+      over: 1030
+      under: 0
+  - name: CURR_SOLAR_PANELS_X_M
+    critical:
+      over: 1030
+      under: 0
+  - name: CURR_SOLAR_PANELS_Y_M
+    critical:
+      over: 1030
+      under: 0
+  - name: BATT_VOLT
+    critical:
+      over: 8400
+      under: 6700
+  - name: CURR_SOLAR
+    critical:
+      over: 4120
+      under: 0
+  - name: CURR_BATT_IN
+    critical:
+      over: 2849
+      under: 0
+  - name: CURR_BATT_OUT
+    critical:
+      over: 800
+      under: 200
+  - name: CURR_OUTPUT_MAIN_OBC_A
+    critical:
+      over: 330
+      under: 0
+  - name: CURR_OUTPUT_SRS3_A
+    critical:
+      over: 720
+      under: 0
+  - name: CURR_OUTPUT_ADCS_A
+    critical:
+      over: 10
+      under: 0
+  - name: CURR_OUTPUT_MAIN_OBC_B
+    critical:
+      over: 330
+      under: 0
+  - name: CURR_OUTPUT_SRS3_B
+    critical:
+      over: 720
+      under: 0
+  - name: CURR_OUTPUT_ADCS_B
+    critical:
+      over: 10
+      under: 0
+  - name: CURR_OUTPUT_RW
+    critical:
+      over: 10
+      under: 0
+  - name: CURR_OUTPUT_DSTRX3
+    critical:
+      over: 10
+      under: 0
+  - name: ALWAYS_ON_CURR_OUTPUT_3V3
+    critical:
+      over: 200
+      under: 0
+  - name: ALWAYS_ON_CURR_OUTPUT_5V
+    critical:
+      over: 90
+      under: 35
+  - name: OUTPUT_CONV_VOLT_3V3
+    critical: 
+      over: 3430
+      under: 3140
+  - name: OUTPUT_CONV_VOLT_5V_A
+    critical:
+      over: 5130
+      under: 4750
+  - name: OUTPUT_CONV_VOLT_5V_B
+    critical:
+      over: 5130
+      under: 4750
+  - name: OUTPUT_CONV_VOLT_12V
+    critical:
+      over: 12280
+      under: 10000
+  - name: OUTPUT_CONV_STATUS_12V
+    critical:
+      mismatch: 1
+  - name: OUTPUT_CONV_STATUS_5V_B
+    critical:
+      mismatch: 1
+  - name: OUTPUT_CONV_STATUS_5V_A
+    critical:
+      mismatch: 1
+  - name: OUTPUT_CONV_STATUS_3V3
+    critical:
+      mismatch: 1
+  - name: OUTPUT_STATUS_RW
+    critical:
+      mismatch: 0
+  - name: OUTPUT_STATUS_ADCS_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_STATUS_SRS3_B
+    critical:
+      mismatch: 1
+  - name: OUTPUT_STATUS_MAIN_OBC_B
+    critical:
+      mismatch: 1
+  - name: OUTPUT_STATUS_ADCS_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_STATUS_SRS3_A
+    critical:
+      mismatch: 1
+  - name: OUTPUT_STATUS_MAIN_OBC_A
+    critical:
+      mismatch: 1
+  - name: OUTPUT_STATUS_DSTRX3
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_RW
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_ADCS_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_SRS3_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_MAIN_OBC_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_ADCS_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_SRS3_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_MAIN_OBC_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_STATUS_DSTRX3
+    critical:
+      mismatch: 0
+  - name: PROTECTED_OUTPUT_ACCESS_COUNT
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_MAIN_OBC_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_SRS3_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_ADCS_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_MAIN_OBC_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_SRS3_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_ADCS_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_RW
+    critical:
+      mismatch: 0
+  - name: OUTPUT_ON_DELTA_DSTRX3
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_MAIN_OBC_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_SRS3_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_ADCS_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_MAIN_OBC_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_SRS3_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_ADCS_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_RW
+    critical:
+      mismatch: 0
+  - name: OUTPUT_OFF_DELTA_DSTRX3
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_MAIN_OBC_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_SRS3_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_ADCS_A
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_MAIN_OBC_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_SRS3_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_ADCS_B
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_RW
+    critical:
+      mismatch: 0
+  - name: OUTPUT_FAULT_COUNT_DSTRX3
+    critical:
+      mismatch: 0
+  - name: TEMP_MPPT_X_P
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_MPPT_Y_P
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_MPPT_X_M
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_MPPT_Y_M
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_CONV_3V3
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_CONV_5V_A
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_CONV_5V_B
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_CONV_12V
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_BATT_ON_BOARD
+    critical:
+      over: 60
+      under: -20
+  - name: TEMP_BATT_EXT_IN_USE
+    critical:
+      over: 60
+      under: -20
+  - name: BATT_STATE
+    critical:
+      over: 3
+      under: 2
+  - name: MPPT_MODE
+    critical:
+      mismatch: 0
+  - name: BATT_HEATER_MODE
+    critical:
+      mismatch: 1
+  - name: BATT_HEATER_STATE
+    critical:
+      over: 1
+      under: 0
+  - name: PING_WDT_TOGGLES
+    critical:
+      mismatch: 0
+  - name: PING_WDT_TURN_OFFS
+    critical:
+      mismatch: 0
+  - name: BATT_INVALID_MEASUREMENT_COUNT
+    critical:
+      mismatch: 0
+# REPLY_STARTUP_TELEMETRY
+  - name: STATUS_S
+    critical:
+      mismatch: 0
+  - name: TIMESTAMP_S
+    critical:
+      over: 1734177500
+      under: 1734177200
+  - name: LAST_RESET_REASON_REGISTER_7TO0
+    critical:
+      mismatch: 0x00
+  - name: LAST_RESET_REASON_REGISTER_15TO8
+    critical:
+      mismatch: 0x00
+  - name: LAST_RESET_REASON_REGISTER_23TO16
+    critical:
+      mismatch: 0x80
+  - name: LAST_RESET_REASON_REGISTER_31TO24
+    critical:
+      mismatch: 0x0C
+  - name: BOOT_COUNT_S
+    critical:
+      mismatch: 321
+  - name: FALLBACK_CONFIG_USED
+    critical:
+      mismatch: 0
+  - name: RTC_INIT
+    critical:
+      mismatch: 1
+  - name: RTC_CLOCK_SOURCE_LSE
+    critical:
+      mismatch: 1
+  - name: FLASH_APPLICATION_INIT
+    critical:
+      mismatch: 1
+  - name: FRAM_4K_PARTITION_INIT
+    critical:
+      mismatch: 0
+  - name: FRAM_520K_PARTITION_INIT
+    critical:
+      mismatch: 0
+  - name: INTERNAL_FLASH_PARTITION_INIT
+    critical:
+      mismatch: 0
+  - name: FW_UPDATE_INIT
+    critical:
+      mismatch: 0
+  - name: FILE_SYSTEM_INIT
+    critical:
+      mismatch: 0
+  - name: FILE_TRANSFER_INIT
+    critical:
+      mismatch: 0
+  - name: SUPERVISOR_INIT
+    critical:
+      mismatch: 0
+  - name: UART1_APPLICATION_INIT
+    critical:
+      mismatch: 1
+  - name: USER2_APPLICATION_INIT
+    critical:
+      mismatch: 1
+  - name: TEMP_SENSOR_INIT
+    critical:
+      mismatch: 0

--- a/py/check/main_check.yaml
+++ b/py/check/main_check.yaml
@@ -1,0 +1,328 @@
+prefix: /SCSAT1/MAIN/
+csv-dir: "./main_check_csv"
+parameters:
+# SYSTEM_HK
+  - name: SYSTEM_HK_SEQ_NO
+    critical:
+      over: 1080
+      under: 0
+  - name: WALL_CLOCK
+    critical:
+      over: 1734188000
+      under: 1734177200
+  - name: SYSTEM_UP_TIME
+    critical:
+      over: 10800
+      under: 0
+  - name: SW_VERSION
+    critical:
+      mismatch: 0x15834B0F
+  - name: CM3_BOOT_COUNT
+    critical:
+      mismatch: 2
+  - name: RESERVED
+    critical:
+      mismatch: 0
+  - name: DRV2_POWER_STATUS
+    critical:
+      mismatch: 0
+  - name: DRV1_POWER_STATUS
+    critical:
+      mismatch: 0
+  - name: DSTRX_IO_POWER_STATUS
+    critical:
+      mismatch: 0
+  - name: PDU_03_POWER_STATUS
+    critical:
+      mismatch: 0
+  - name: PAYLOAD_POWER_STATUS
+    critical:
+      mismatch: 0
+  - name: ADCS_POWER_STATUS
+    critical:
+      mismatch: 1
+  - name: FPGA_VERSION
+    critical:
+      mismatch: 0x1E082FD6
+  - name: FPGA_CONFIG_BANK
+    critical:
+      mismatch: 0
+  - name: FPGA_FALLBACK_STATE
+    critical:
+      mismatch: 5
+  - name: RECEIVED_COMMAND_COUNT
+    critical:
+      over: 5
+      under: 2
+  - name: LAST_CSP_PORT
+    critical:
+      mismatch: 1
+  - name: LAST_COMMAND_ID
+    critical:
+      mismatch: 0
+  - name: SRAM_ECC_ERROR_COUNT_BY_MEMORY_SCRUB
+    critical:
+      mismatch: 0
+  - name: SRAM_ECC_ERROR_COUNT_BY_BUS_READ
+    critical:
+      mismatch: 0
+  - name: SEM_ERROR_COUNT
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_TEMP_1_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_TEMP_1
+    critical:
+      over: 80
+      under: -40
+  - name: OBC_MODULE_TEMP_2_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_TEMP_2
+    critical:
+      over: 80
+      under: -40
+  - name: OBC_MODULE_TEMP_3_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_TEMP_3
+    critical:
+      over: 80
+      under: -40
+  - name: FPGA_TEMP_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: FPGA_TEMP
+    critical:
+      over: 80
+      under: -40
+  - name: IO_BOARD_TEMP_1_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_TEMP_1
+    critical:
+      over: 85
+      under: -40
+  - name: IO_BOARD_TEMP_2_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_TEMP_2
+    critical:
+      over: 85
+      under: -40
+  - name: TEMP_X_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_X_P
+    critical:
+      over: 85
+      under: -40
+  - name: TEMP_X_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_X_M
+    critical:
+      over: 85
+      under: -40
+  - name: TEMP_Y_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_Y_P
+    critical:
+      over: 85
+      under: -40
+  - name: TEMP_Y_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_Y_M
+    critical:
+      over: 85
+      under: -40
+  - name: OBC_MODULE_1V0_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_1V0_CURR
+    critical:
+      over: 4000
+      under: 1450
+  - name: OBC_MODULE_1V0_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_1V0_VOLT
+    critical:
+      over: 1030
+      under: 970
+  - name: OBC_MODULE_1V8_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_1V8_CURR
+    critical:
+      over: 1350
+      under: 950
+  - name: OBC_MODULE_1V8_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_1V8_VOLT
+    critical:
+      over: 1860
+      under: 1750
+  - name: OBC_MODULE_3V3_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_CURR
+    critical:
+      over: 1000
+      under: 350
+  - name: OBC_MODULE_3V3_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_VOLT
+    critical:
+      over: 3480
+      under: 3000
+  - name: OBC_MODULE_3V3_SYS_A_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_SYS_A_CURR
+    critical:
+      over: 4000
+      under: 0
+  - name: OBC_MODULE_3V3_SYS_A_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_SYS_A_VOLT
+    critical:
+      over: 3480
+      under: 3290
+  - name: OBC_MODULE_3V3_SYS_B_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_SYS_B_CURR
+    critical:
+      over: 4000
+      under: 0
+  - name: OBC_MODULE_3V3_SYS_B_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_SYS_B_VOLT
+    critical:
+      over: 3480
+      under: 3290
+  - name: OBC_MODULE_3V3_IO_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_IO_CURR
+    critical:
+      over: 160
+      under: 0
+  - name: OBC_MODULE_3V3_IO_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: OBC_MODULE_3V3_IO_VOLT
+    critical:
+      over: 3480
+      under: 3000
+  - name: FPGA_VCCINT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: FPGA_VCCINT
+    critical:
+      over: 1030
+      under: 970
+  - name: FPGA_VCCAUX_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: FPGA_VCCAUX
+    critical:
+      over: 1860
+      under: 1750
+  - name: FPGA_VCCBRAM_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: FPGA_VCCBRAM
+    critical:
+      over: 1030
+      under: 970
+  - name: IO_BOARD_PDU_3V3_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_PDU_3V3_CURR
+    critical:
+      over: 7400
+      under: 4000
+  - name: IO_BOARD_PDU_3V3_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_PDU_3V3_VOLT
+    critical:
+      over: 3480
+      under: 3290
+  - name: IO_BOARD_3V3_SYS_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_3V3_SYS_CURR
+    critical:
+      over: 2500
+      under: 1900
+  - name: IO_BOARD_3V3_SYS_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_3V3_SYS_VOLT
+    critical:
+      over: 3480
+      under: 3140
+  - name: IO_BOARD_3V3_CURR_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_3V3_CURR
+    critical:
+      over: 5200
+      under: 2000
+  - name: IO_BOARD_3V3_VOLT_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: IO_BOARD_3V3_VOLT
+    critical:
+      over: 3480
+      under: 3140
+  - name: MAGNETOMETER_Y_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: MAGNETOMETER_Y_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_MAGNETOMETER_Y_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_MAGNETOMETER_Y_P
+    critical:
+      over: 85
+      under: -40
+  - name: TEMP_ON_MAGNETOMETER_Y_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_MAGNETOMETER_Y_M
+    critical:
+      over: 85
+      under: -40
+  - name: SUN_SENSOR_Y_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: SUN_SENSOR_Y_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_SUN_SENSOR_Y_P_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_SUN_SENSOR_Y_P
+    critical:
+      over: 100
+      under: -40
+  - name: TEMP_ON_SUN_SENSOR_Y_M_SENSOR_STATUS
+    critical:
+      mismatch: 0
+  - name: TEMP_ON_SUN_SENSOR_Y_M
+    critical:
+      over: 100
+      under: -40

--- a/py/check/srs3_check.yaml
+++ b/py/check/srs3_check.yaml
@@ -1,0 +1,271 @@
+prefix: /SCSAT1/SRS3/
+csv-dir: "./srs3_check_csv"
+parameters:
+# REPLY_PROP_LIST_TM_GRP
+  - name: TEMP_MCU
+    critical:
+      over: 7000
+      under: -4000
+  - name: TEMP_POWER
+    critical:
+      over: 7000
+      under: -4000
+  - name: TEMP_LNA
+    critical:
+      over: 7000
+      under: -4000
+  - name: TEMP_PA
+    critical:
+      over: 7000
+      under: -4000
+  - name: VOLT_VIN
+    critical:
+      over: 5130
+      under: 4750
+  - name: VOLT_VREG
+    critical:
+      over: 3950
+      under: 3550
+  - name: VOLT_3V3
+    critical:
+      over: 3450
+      under: 3200
+  - name: CURR_VIN
+    critical:
+      over: 720
+      under: 0
+  - name: CURR_VREG
+    critical:
+      over: 960
+      under: 0
+  - name: CURR_3V3
+    critical:
+      over: 330
+      under: 0
+  - name: POWER_VIN
+    critical:
+      over: 3694
+      under: 0
+  - name: POWER_VREG
+    critical:
+      over: 3792
+      under: 0
+  - name: POWER_3V3
+    critical:
+      over: 1139
+      under: 0
+# REPLY_PROP_LIST_SYS_GRP_1
+  - name: NAME
+    critical:
+      mismatch: "srs-3 on sc-sat1"
+  - name: SERIAL
+    critical:
+      mismatch: 0x30CC31C6
+  - name: SW_VERSION
+    critical:
+      mismatch: 0x02070000
+  - name: BOOTCOUNT_SYS
+    critical:
+      mismatch: 158
+  - name: GWDT_INIT
+    critical:
+      mismatch: 108000
+  - name: GWDT_COUNTER_SYS
+    critical:
+      over: 108000
+      under: 97200
+  - name: GWDT_RESET
+    critical:
+      mismatch: 0x00000000
+  - name: CSP_ADDRESS
+    critical:
+      mismatch: 2
+  - name: CSP_ROUTES
+    critical:
+      mismatch: "0/0 CAN, 1/5 SPACE"
+  - name: CSP_MTU
+    critical:
+      mismatch: 256
+  - name: CAN_RATE
+    critical:
+      mismatch: 1000000
+  - name: CAN_PROMISC
+    critical:
+      mismatch: 1
+  - name: UART_RATE
+    critical:
+      mismatch: 115200
+  - name: UART_MULTIDROP
+    critical:
+      mismatch: 0
+  - name: NET_ENABLE
+    critical:
+      mismatch: 0
+  - name: NET_EN_IP
+    critical:
+      mismatch: "192.168.100.2"
+# REPLY_PROP_LIST_SYS_GRP_2
+  - name: NET_EN_PREFIX
+    critical:
+      mismatch: 24
+  - name: NET_EN_GW
+    critical:
+      mismatch: "192.168.100.1"
+  - name: NET_RF_IP
+    critical:
+      mismatch: "192.168.200.2"
+  - name: NET_RF_PREFIX
+    critical:
+      mismatch: 24
+  - name: NET_RF_GW
+    critical:
+      mismatch: "192.168.200.1"
+# REPLY_PROP_LIST_TX_GRP
+  - name: ALLOW_ALWAYS
+    critical:
+      mismatch: 1
+  - name: ALLOW_TIME
+    critical:
+      mismatch: 0
+  - name: FREQUENCY_TX
+    critical:
+      mismatch: 2278600000
+  - name: BIT_RATE_TX
+    critical:
+      mismatch: 128000
+  - name: BT_PRODUCT
+    critical:
+      mismatch: 50
+  - name: POWER_OUT
+    critical:
+      mismatch: 30
+  - name: POWER_GAIN
+    critical:
+      mismatch: 2500
+  - name: ALC_MODE
+    critical:
+      mismatch: 2
+  - name: ALC_KP
+    critical:
+      mismatch: 40
+  - name: ALC_LIMIT
+    critical:
+      mismatch: 200
+  - name: REED_SOLOMON_TX
+    critical:
+      mismatch: 1
+  - name: CONVOLUTION_CODING_TX
+    critical:
+      mismatch: 1
+  - name: RANDOMIZE_TX
+    critical:
+      mismatch: 1
+  - name: CRC_TX
+    critical:
+      mismatch: 1
+  - name: IDLE_FRAMES
+    critical:
+      mismatch: 0
+  - name: TRAIN_TYPE
+    critical:
+      mismatch: 0
+  - name: PREAMBLE_SIZE
+    critical:
+      mismatch: 16
+  - name: POSTAMBLE_SIZE
+    critical:
+      mismatch: 0
+  - name: MIDAMBLE_SIZE
+    critical:
+      mismatch: 0
+  - name: PACKET_SIZE_TX
+    critical:
+      mismatch: 256
+  - name: ID_TX
+    critical:
+      mismatch: 0
+  - name: CRYPTO_KEY_TX
+    critical:
+      mismatch: 0
+  - name: CRYPTO_ENCRYPT
+    critical:
+      mismatch: 0
+  - name: CRYPTO_AUTH_TX
+    critical:
+      mismatch: 0
+  - name: SEND_FRAMES
+    critical:
+      over: 40
+      under: 10
+  - name: POWER_FORWARD
+    critical:
+      over: 30.5
+      under: 29.5
+  - name: POWER_REFLECT
+    critical:
+      over: 16
+      under: 0
+  - name: OVER_POWER_COUNT
+    critical:
+      mismatch: 0
+  - name: PLL_NO_LOCK_COUNT_TX
+    critical:
+      mismatch: 0
+# REPLY_PROP_LIST_RX_GRP
+  - name: FREQUENCY_RX
+    critical:
+      mismatch: 2105350000
+  - name: BIT_RATE_RX
+    critical:
+      mismatch: 128000
+  - name: BAND_WIDTH
+    critical:
+      mismatch: 150
+  - name: REED_SOLOMON_RX
+    critical:
+      mismatch: 1
+  - name: CONVOLUTION_CODING_RX
+    critical:
+      mismatch: 1
+  - name: RANDOMIZE_RX
+    critical:
+      mismatch: 1
+  - name: CRC_RX
+    critical:
+      mismatch: 1
+  - name: PACKET_SIZE_RX
+    critical:
+      mismatch: 217
+  - name: ID_RX
+    critical:
+      mismatch: 0
+  - name: CRYPTO_KEY_RX
+    critical:
+      mismatch: 0
+  - name: CRYPTO_DECRYPT
+    critical:
+      mismatch: 0
+  - name: CRYPTO_AUTH
+    critical:
+      mismatch: 0
+  - name: LOCAL_DROP
+    critical:
+      mismatch: 0
+  - name: RECV_FRAMES
+    critical:
+      over: 40
+      under: 10
+  - name: DETECTED
+    critical:
+      over: 40
+      under: 10
+  - name: RSSI
+    critical:
+      over: -30
+      under: -107
+  - name: FREQUENCY_ERR
+    critical:
+      mismatch: 0
+  - name: PLL_NO_LOCK_COUNT_RX
+    critical:
+      mismatch: 0

--- a/py/check_params.py
+++ b/py/check_params.py
@@ -1,0 +1,151 @@
+import argparse
+import os
+import yaml
+from datetime import datetime, timezone, timedelta
+from yamcs.client import YamcsClient
+
+DEFAULT_YAMCS_URL = 'localhost:8090'
+DEFAULT_YAMCS_INSTANCE = 'scsat1'
+BLANK_TIME_SEC = 60
+
+configs = {}
+mismatchs = {}
+matchs = {}
+overs = {}
+unders = {}
+params = []
+times = {}
+values = {}
+errors = {}
+
+
+def write_csv():
+
+    for param in params:
+        csvdir = configs['csv-dir']
+        csvname = param.split('/')[-1]
+        csvname = csvname.lower()
+        with open(f"{csvdir}/{csvname}.csv", 'w',  encoding="utf-8") as outf:
+            for idx, time in enumerate(times[param]):
+                outf.write(f"{time},\"{values[param][idx]}\",{errors[param][idx]}\n")
+                if errors[param][idx] != '':
+                    print(f"\033[31m{time},{param},\"{values[param][idx]}\",{errors[param][idx]}\033[0m")
+
+
+def check_yamcs_params(args):
+
+    search_min = args.min
+    yamcs_url = args.url
+    yamcs_instance = args.instance
+    start_time = args.start
+    end_time = args.end
+
+    client = YamcsClient(yamcs_url)
+    archive = client.get_archive(instance=yamcs_instance)
+
+    now = datetime.now(tz=timezone.utc)
+
+    if end_time is None:
+        stop = now
+    else:
+        stop = datetime.strptime(end_time + '+0900', '%Y-%m-%d %H:%M:%S%z')
+
+    if search_min < 0:
+        if start_time is not None:
+            start = datetime.strptime(start_time + '+0900', '%Y-%m-%d %H:%M:%S%z')
+        else:
+            start = None
+    else:
+        start = stop - timedelta(minutes=search_min)
+
+    try:
+        stream = archive.stream_parameter_values(params, start=start, stop=stop)
+        for pdata in stream:
+            for data in pdata:
+                target = data.name
+                time = data.generation_time.strftime("%Y-%m-%d %H:%M:%S %z")
+
+                if isinstance(data.raw_value, (bytes, bytearray)):
+                    val = int.from_bytes(data.raw_value, byteorder='big')
+                else:
+                    val = data.raw_value
+
+                times[target].append(time)
+                values[target].append(val)
+
+                if target in mismatchs and val != mismatchs[target]:
+                    errors[target].append('Mismatch')
+                elif target in matchs and val == matchs[target]:
+                    errors[target].append('Match')
+                elif target in overs and val > overs[target]:
+                    errors[target].append('Over')
+                elif target in unders and val < unders[target]:
+                    errors[target].append('Under')
+                else:
+                    errors[target].append('')
+
+    except Exception as e:
+        print(e)
+
+
+def init(yaml_file):
+
+    global configs
+
+    with open(yaml_file, 'r') as file:
+        configs = yaml.safe_load(file)
+
+    if not os.path.exists(configs['csv-dir']):
+        os.makedirs(configs['csv-dir'])
+
+    prefix = configs['prefix']
+
+    for param in configs['parameters']:
+        target = prefix + param['name']
+        params.append(target)
+        times[target] = []
+        values[target] = []
+        errors[target] = []
+        if 'mismatch' in param['critical']:
+            mismatchs[target] = param['critical']['mismatch']
+        elif 'match' in param['critical']:
+            matchs[target] = param['critical']['match']
+        elif 'over' in param['critical']:
+            overs[target] = param['critical']['over']
+        elif 'under' in param['critical']:
+            unders[target] = param['critical']['under']
+
+
+def main(args):
+
+    for yaml_file in args.yaml:
+
+        if not os.path.exists(yaml_file):
+            print(f"{yaml_file} is not exist, so skip the check the parameters")
+            continue
+        else:
+            print(f"Start to check the parameters according to {yaml_file}")
+
+        init(yaml_file)
+        check_yamcs_params(args)
+        write_csv()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="SC-Sat1 Yamcs telemetry parse tool")
+    parser.add_argument("--yaml", type=str, required=True, nargs="+",
+                        help="Target yaml files")
+    parser.add_argument("--url", type=str, default=DEFAULT_YAMCS_URL,
+                        help=f"Yamcs URL and Port number (default: {DEFAULT_YAMCS_URL})")
+    parser.add_argument("--instance", type=str, default=DEFAULT_YAMCS_INSTANCE,
+                        help=f"Yamcs instance name (default: {DEFAULT_YAMCS_INSTANCE})")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--min", type=int, default=-1,
+                       help="Target minutes from current time for searching")
+    group.add_argument("--start", type=str, default=None,
+                       help="Start time for searching")
+    parser.add_argument("--end", type=str, default=None,
+                        help="End time for searching")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Adds a script to validate Yamcs data based on parameters and comparison values defined in a YAML file. Currently, YAML definitions are provided only for MAIN/EPS/SRS-3, which are active during initial operations. The comparison values are also set to what is expected to be obtained during the first AOS. This script displays errors in the standard output when detected and saves all validation results in a CSV file.