### PR TITLE
Add functionality to modify the Generation Time setting

### DIFF
--- a/INSTALL.org
+++ b/INSTALL.org
@@ -77,6 +77,18 @@ Debian Linux-based distribution.
     sudo chmod a+rw /opt/yamcs/log/
     #+end_example
 
+* Implementing additional features
+  * Build the project inside 'java' and create the jar file
+    #+begin_example
+    cd java
+    mvn package
+    #+end_example
+
+  * Copy the created jar file to the Yamcs library directory
+    #+begin_example
+    sudo cp target/scsat1_packet_preprpcessor-1.0.0.jar /opt/yamcs/lib/
+    #+end_example
+
 * Run Yamcs
 
   * Run

--- a/etc/yamcs.scsat1.yaml
+++ b/etc/yamcs.scsat1.yaml
@@ -28,16 +28,47 @@ services:
 dataLinks:
     - name: tm_realtime
       class: org.yamcs.tctm.UdpTmDataLink
-      packetPreprocessorClassName: org.yamcs.tctm.GenericPacketPreprocessor
+      packetPreprocessorClassName: org.yamcs.tctm.Scsat1PacketPreprocessor
       packetPreprocessorArgs:
-        errorDetection: none
-        useLocalGenerationTime: true
-        seqCountOffset: -1
-        timestampOffset: -1
+        timesettings:
+          - sourceId: 8 # MAIN
+            byteOrder: LITTLE_ENDIAN
+            timestampOffset: 9 # /SCSAT1/MAIN/WALL_CLOCK(Loc:9)
+            timeEncoding:
+              type: FIXED
+              size: 4
+              epoch: UNIX
+              multiplier: 1000
+            tmDataList:
+              # /SCSAT1/MAIN/SYSTEM_HK
+              - dport: 10
+                commandId: [0]
+          - sourceId: 16 # ADCS
+            byteOrder: LITTLE_ENDIAN
+            timestampOffset: 9 # /SCSAT1/ADCS/WALL_CLOCK(Loc:9)
+            timeEncoding:
+              type: FIXED
+              size: 4
+              epoch: UNIX
+              multiplier: 1000
+            tmDataList:
+              # /SCSAT1/ADCS/SYSTEM_HK
+              - dport: 10
+                commandId: [0]
+          - sourceId: 4 # EPS
+            timestampOffset: 6 # /SCSAT1/EPS/TIMESTAMP_S(Loc:6)
+            byteOrder: LITTLE_ENDIAN
+            timeEncoding:
+              type: FLOAT64
+              epoch: UNIX
+            tmDataList:
+              # /SCSAT1/EPS/REPLY_GENERAL_TELEMETRY, REQ_STARTUP_TELEMETRY
+              - sport: 7
+                commandId: [0,1]
       stream: tm_realtime
       port: 52004
       # Give the embedded simulator some time to boot up
-      #initialDelay: 2000      
+      #initialDelay: 2000
     - name: tm_dump
       class: org.yamcs.tctm.TcpTmDataLink
       stream: tm_dump

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spacecubics.scsat1</groupId>
+  <artifactId>scsat1_packet_preprpcessor</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <name>Scsat1PacketPreprocessor</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <yamcsVersion>5.9.3</yamcsVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.yamcs</groupId>
+      <artifactId>yamcs-core</artifactId>
+      <version>${yamcsVersion}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.yamcs</groupId>
+        <artifactId>yamcs-maven-plugin</artifactId>
+        <version>1.3.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java/src/main/java/Scsat1PacketPreprocessor.java
+++ b/java/src/main/java/Scsat1PacketPreprocessor.java
@@ -1,0 +1,186 @@
+package org.yamcs.tctm;
+
+import java.nio.ByteOrder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.yamcs.TmPacket;
+import org.yamcs.YConfiguration;
+import org.yamcs.time.FixedSizeTimeDecoder;
+import org.yamcs.time.Float64TimeDecoder;
+import org.yamcs.utils.TimeEncoding;
+import org.yamcs.time.TimeDecoder;
+import org.yamcs.tctm.csp.CspPacket;
+import org.yamcs.utils.ByteArrayUtils;
+
+public class Scsat1PacketPreprocessor extends AbstractPacketPreprocessor {
+    static class TmData {
+        private final int dport;
+        private final int sport;
+        private final List<Integer> commandIdList;
+        private final int commandIdOffset = 4;
+        private final int commandIdLength = 1;
+
+        public TmData(YConfiguration config) {
+            dport = config.getInt("dport", -1);
+            sport = config.getInt("sport", -1);
+            // If commandId is not specified, initialize it to null
+            if (config.containsKey("commandId")) {
+                commandIdList = config.getList("commandId");
+            } else {
+                commandIdList = null;
+            }
+        }
+
+        // Validate if port is matches the packet's port
+        private boolean isMatchedPacketPortNum(byte[] packet) {
+            CspPacket cspHeader = new CspPacket(packet);
+            int packetDport = cspHeader.getDestinationPort();
+            int packetSport = cspHeader.getSourcePort();
+            // The port doesn't match the configured value
+            if (packetDport != dport && dport != -1) {
+                return false;
+            }
+            if (packetSport != sport && sport != -1) {
+                return false;
+            }
+            // Both ports match the configured value or are unconfigured
+            return true;
+        }
+
+        // Validate if command ID is unspecified or matches the packet's command ID
+        private boolean isValidPacketCommandId(byte[] packet) {
+            if (packet.length < commandIdOffset + commandIdLength){
+                return false;
+            }
+            int packetCommandId = ByteArrayUtils.decodeUnsignedByte(packet, commandIdOffset);
+            if (commandIdList == null || commandIdList.isEmpty() || commandIdList.contains(packetCommandId)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        public boolean isValidPortAndCommandId(byte[] packet) {
+            boolean isMatchedPortNum = isMatchedPacketPortNum(packet);
+            boolean isValidCommandId = isValidPacketCommandId(packet);
+            if (isMatchedPortNum && isValidCommandId) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    class TimeSettings {
+        private final int timestampOffset;
+        private final ByteOrder byteOrder;
+        private final TimeDecoder timeDecoder;
+        private final TimeEpochs timeEpoch;
+        private final List<TmData> tmDataList;
+
+        TimeSettings(YConfiguration config) {
+            timestampOffset = config.getInt("timestampOffset", -1);
+            // Byte order setting (default: BIG_ENDIAN)
+            String byteOrderStr = config.getString("byteOrder", "BIG_ENDIAN");
+            if ("LITTLE_ENDIAN".equalsIgnoreCase(byteOrderStr)) {
+                byteOrder = ByteOrder.LITTLE_ENDIAN;
+            } else {
+                byteOrder = ByteOrder.BIG_ENDIAN;
+            }
+            // Read the setting of target telemetry
+            if (config.containsKey("tmDataList")) {
+                tmDataList = config.getConfigList("tmDataList").stream()
+                                .map(tmConfig -> new TmData(tmConfig))
+                                .collect(Collectors.toList());
+            } else {
+                tmDataList = null;
+            }
+            // Time Encoding setting
+            if (config.containsKey("timeEncoding")) {
+                YConfiguration timeEncodingConfig = config.getConfig("timeEncoding");
+                int size = timeEncodingConfig.getInt("size", 8);
+                long multiplier = timeEncodingConfig.getLong("multiplier", 1);
+                String type = timeEncodingConfig.getString("type", "FIXED");
+                String epoc = timeEncodingConfig.getString("epoch", "UNIX");
+                if ("FLOAT64".equals(type)) {
+                    timeDecoder = new Float64TimeDecoder(byteOrder);
+                } else {
+                    timeDecoder = new FixedSizeTimeDecoder(byteOrder, size, multiplier);
+                }
+                if ("UNIX".equals(epoc)) {
+                    timeEpoch = TimeEpochs.UNIX;
+                } else {
+                    timeEpoch = TimeEpochs.NONE;
+                }
+            } else {
+                timeDecoder = new FixedSizeTimeDecoder(byteOrder, 8, 1);
+                timeEpoch = TimeEpochs.UNIX;
+            }
+        }
+
+        public void setPacketGenerationTime(TmPacket tmPacket) {
+            byte[] packet = tmPacket.getPacket();
+            if (timestampOffset < 0 || tmDataList == null) {
+                tmPacket.setGenerationTime(tmPacket.getReceptionTime());
+                return;
+            }
+            for (TmData data : tmDataList) {
+                if (data.isValidPortAndCommandId(packet)) {
+                    // The packet matches the YAML-specified telemetry
+                    // If commandID is not specified, any packet with a matching port is valid
+                    Scsat1PacketPreprocessor.this.timeDecoder = timeDecoder;
+                    Scsat1PacketPreprocessor.this.timeEpoch = timeEpoch;
+                    setRealtimePacketTime(tmPacket, timestampOffset);
+                    return;
+                }
+            }
+            // No match found in tmDataList
+            tmPacket.setGenerationTime(tmPacket.getReceptionTime());
+            return;
+        }
+    }
+
+    // Save the generation time setting
+    private Map<Integer, TimeSettings> timeSettingsMap = new HashMap<>();
+
+    public Scsat1PacketPreprocessor(String yamcsInstance, YConfiguration config) {
+        super(yamcsInstance, config);
+        if (!config.containsKey("timesettings")) {
+            return;
+        }
+        // Save the time setting read from yaml for each source ID
+        List<YConfiguration> timesettings = config.getConfigList("timesettings");
+        for (YConfiguration timesettingConfig : timesettings) {
+            int srcId =  timesettingConfig.getInt("sourceId");
+            TimeSettings srcTimesetting = new TimeSettings(timesettingConfig);
+            timeSettingsMap.put(srcId, srcTimesetting);
+        }
+    }
+
+    // Sets generation time from source ID, or uses reception time if not found
+    public void setGenerationTimeBySourceId(TmPacket tmPacket) {
+        byte[] packet = tmPacket.getPacket();
+        CspPacket cspHeader = new CspPacket(packet);
+        int srcId = cspHeader.getSource();
+        TimeSettings settings = timeSettingsMap.get(srcId);
+        if (settings == null) {
+            tmPacket.setGenerationTime(tmPacket.getReceptionTime());
+            return;
+        }
+        settings.setPacketGenerationTime(tmPacket);
+    }
+
+    @Override
+    public TmPacket process(TmPacket tmPacket) {
+        setGenerationTimeBySourceId(tmPacket);
+        return tmPacket;
+    }
+
+    @Override
+    protected TimeDecoderType getDefaultDecoderType() {
+        return TimeDecoderType.FIXED;
+    }
+}


### PR DESCRIPTION
This pull request is a continuation of [Add functionality to modify the Generation Time setting #90](https://github.com/spacecubics/scsat1-mcs/pull/90).

Add functionality to modify the Generation Time setting for Yamcs. The modification can be applied individually based on each telemetry

- Adding files required to create a jar file
- Adding instructions and settings