### PR TITLE
Add apt-get update before package install

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Install xmllint
         run: |
+          sudo apt-get update
           sudo apt-get install libxml2-utils
 
       - name: Validate against XSD

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,5 @@
+[general]
+regex-style-search=true
+
+[ignore-body-lines]
+regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)


### PR DESCRIPTION
Currently, the CI tests for scsat1-mcs install libxml2-util2, but if `apt` index is stale, the installation fail as shown below.

```    
    E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/
      libx/libxml2/libxml2-utils_2.9.14%2bdfsg-1.3ubuntu3.3_amd64.deb
      404  Not Found [IP: 52.252.163.49 80]
```
   
As recommended in the following documentation[1], this commit adds `apt-get update` process before install.
    
[1]: https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners#installing-software-on-ubuntu-runners
    
