### PR TITLE
Upgrade Yamcs to 5.12.0 and update configuration

### DIFF
--- a/INSTALL.org
+++ b/INSTALL.org
@@ -11,7 +11,7 @@ Debian Linux-based distribution.
 
   * Download Yamcs rpm package from [[https://github.com/yamcs/yamcs/releases][yamcs github]]
     #+begin_example
-    wget https://github.com/yamcs/yamcs/releases/download/yamcs-5.9.3/yamcs-5.9.3-1.x86_64.rpm
+    wget https://github.com/yamcs/yamcs/releases/download/yamcs-5.12.0/yamcs-5.12.0-1.x86_64.rpm
     #+end_example
 
   * Install alien for convert rpm to deb (Only the first time)
@@ -23,12 +23,12 @@ Debian Linux-based distribution.
 
   * Convert rpm to deb
     #+begin_example
-    sudo alien --script -d -k yamcs-5.9.3-1.x86_64.rpm
+    sudo alien --script -d -k yamcs-5.12.0-1.x86_64.rpm
     #+end_example
 
   * Install deb
     #+begin_example
-    sudo dpkg -i yamcs_5.9.3-1_amd64.deb
+    sudo dpkg -i yamcs_5.12.0-1_amd64.deb
     #+end_example
 
 * Install Java runtime

--- a/etc/processor.yaml
+++ b/etc/processor.yaml
@@ -31,13 +31,6 @@ realtime:
     alarm:
       parameterCheck: true
       parameterServer: enabled
-    parameterCache:
-      enabled: true
-      cacheAll: true
-      #duration in seconds on how long parameters are kept into cache
-      duration: 600
-      #maximum number of entries in the cache for one parameter
-      maxNumEntries: 4096
     tmProcessor:
       #if container entries fit outside the binary packet, setting this to true will cause the error to be ignored, otherwise an exception will be printed in the yamcs logs
       ignoreOutOfContainerEntries: false
@@ -49,13 +42,6 @@ realtime:
 Archive:
   services: 
     - class: org.yamcs.tctm.ReplayService
-  config:        
-    #keep a small cache in case new displays are open while the replay is paused, to have the parameters readily available
-    parameterCache:
-      enabled: true
-      cacheAll: true
-      maxNumEntries: 8
-
 
 #used by the ParameterArchive when rebuilding the parameter archive
 # no need for parameter cache
@@ -65,8 +51,6 @@ ParameterArchive:
   config:
     #Do not generate events in case of errors when processing telemetry (otherwise it will flood the event log with plenty of repeats)
     generateEvents: false
-    parameterCache:
-      enabled: false
 
 #used for performing archive retrievals via replays (e.g. parameter-extractor.sh)
 # we do not want cache in order to extract the minimum data necessary
@@ -76,5 +60,3 @@ ArchiveRetrieval:
   config:
     #Do not generate events in case of errors when processing telemetry (otherwise it will flood the event log with plenty of repeats)
     generateEvents: false
-    parameterCache:
-      enabled: false

--- a/etc/yamcs.scsat1.yaml
+++ b/etc/yamcs.scsat1.yaml
@@ -10,8 +10,7 @@ services:
               - tm_dump
     - class: org.yamcs.parameter.SystemParametersService
       args:
-          provideJvmVariables: true
-          provideFsVariables: true
+        producers: ['jvm', 'fs']
     - class: org.yamcs.ProcessorCreatorService
       args: 
           name: "realtime"
@@ -24,6 +23,13 @@ services:
         backFiller:
           enabled: true
           warmupTime: 60
+    - class: org.yamcs.parameter.ParameterRetrievalService
+      args:
+        parameterCache:
+            enabled: true
+            cacheAll: false
+            duration: 600
+            maxNumEntries: 4096
 
 dataLinks:
     - name: tm_realtime

--- a/etc/yamcs.yaml
+++ b/etc/yamcs.yaml
@@ -9,10 +9,6 @@ services:
       #tlsCert: /opt/yamcs/etc/yamcs-server.crt
       #tlsKey: /opt/yamcs/etc/yamcs-server.key
 
-      # Indicates whether zero-copy can be used to optimize non-ssl static file serving
-      # Leave this true unless you encounter a specific deployment issue (e.g. some docker hosts)
-      zeroCopyEnabled: true
-
       # Configure Cross—origin Resource Sharing for the REST API.
       # This facilitates use of the API in browser applications.
       # Note that as per W3C spec the exact allowed origin MUST be defined if credentials are to be passed.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <yamcsVersion>5.9.3</yamcsVersion>
+    <yamcsVersion>5.12.0</yamcsVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Install-related:
- Update installation steps to use Yamcs 5.12.0
- Bump Yamcs dependency version in pom.xml

Config-related (fix warnings):
- Update parameter cache location
- Handle deprecation of provideJvmVariables / provideFsVariables
- Handle deprecation of zeroCopyEnabled