### PR TITLE
INSTALL.org: Update Yamcs installation steps for latest version

### DIFF
--- a/INSTALL.org
+++ b/INSTALL.org
@@ -35,9 +35,9 @@ Debian Linux-based distribution.
 
   * Install java runtime package
 
-    Note: You need to install JDK 11 or higher.
+    Note: You need to install JDK 17 or higher.
     #+begin_example
-    sudo apt install openjdk-11-jdk
+    sudo apt install openjdk-17-jdk
     #+end_example
 
 * Preparing for configuration and mdb files

--- a/INSTALL.org
+++ b/INSTALL.org
@@ -78,6 +78,11 @@ Debian Linux-based distribution.
     #+end_example
 
 * Implementing additional features
+  * Install java build tool
+    #+begin_example
+    sudo apt install maven
+    #+end_example
+
   * Build the project inside 'java' and create the jar file
     #+begin_example
     cd java


### PR DESCRIPTION
Updated installation instructions to fix issue with updating yamcs version
- Update install steps to use JDK 17 instead of 11
  - The latest Yamcs requirements specify JDK 17 or later.  Accordingly, the installation instructions have been updated.
- Add Maven installation step for Java build
  - A Maven install step is added as a build tool for "Implementing additional features" step uses