### PR TITLE
py: Add backup and restore utility for Yamcs

### DIFF
--- a/py/backup_util.py
+++ b/py/backup_util.py
@@ -1,0 +1,123 @@
+import sys
+import subprocess
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import re
+
+
+def fail_exit(action: str, name: str):
+    print(f"{action} failed for {name}. Exiting.", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_dir(dir_path):
+    if not dir_path.is_dir():
+        print(f"Directory does not exist: {dir_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def create_dir(dir_path):
+    if not dir_path.exists():
+        print(f"Creating output directory: {dir_path}")
+        try:
+            dir_path.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            print(f"Failed to create directory: {dir_path} ({e})", file=sys.stderr)
+            sys.exit(1)
+
+
+def get_max_numbered_file(dir_path, suffix=".txt"):
+    if dir_path.exists():
+        files = dir_path.glob(f"*{suffix}")
+        max_num = None
+        for f in files:
+            try:
+                num = int(f.stem)
+            except ValueError:
+                continue
+            if max_num is None or num > max_num:
+                max_num = num
+    else:
+        create_dir(dir_path)
+        max_num = 0
+    return max_num
+
+
+def list_backups(etc_dir, backup_dir, names=None):
+    # Get the backup list inside the backup directory
+    if names is None:
+        names = get_tablespace_names_from_backup_dir(backup_dir)
+    last_name = sorted(names)[-1]
+    print(f"Listing backups: {last_name}")
+    try:
+        cmd_output = subprocess.check_output(
+            [
+                "/opt/yamcs/bin/yamcsadmin",
+                "--etc-dir", str(etc_dir),
+                "backup", "list",
+                "--backup-dir", str(backup_dir / last_name),
+            ],
+        )
+    except subprocess.CalledProcessError:
+        list_fail_exit(last_name)
+    # Get Yamcs version data at the time of backup
+    yamcs_version_dict = get_yamcs_version_dict(backup_dir/"config")
+    # Prints the header of lists
+    lines = cmd_output.decode("utf-8").strip().splitlines()
+    name_list = re.split(r"\s{2,}", lines[0].strip())
+    # Pad "time [JST]" to 19 chars (datetime "%Y-%m-%d %H:%M:%S" is 19 chars)
+    name_list[-1] = "time (JST)".ljust(19)
+    name_list = name_list + ["yamcs_version"]
+    name_len_list = [len(name)+2 for name in name_list]
+    header = "".join(n.ljust(w) for n, w in zip(name_list, name_len_list))
+    print(header)
+    # Prints the baskup list and yamcs version
+    for backup_data in lines[1:]:
+        items = backup_data.split()
+        # Convert UTC time to JST
+        utc_time = datetime.strptime(items[-1], "%Y-%m-%dT%H:%M:%SZ[%Z]").replace(tzinfo=ZoneInfo("UTC"))
+        jst_time = utc_time.astimezone(ZoneInfo("Asia/Tokyo"))
+        items[-1] = jst_time.strftime("%Y-%m-%d %H:%M:%S")
+        # Get Yamcs version of backup id
+        backup_id = items[0]
+        yamcs_version = yamcs_version_dict.get(f"{backup_id}", "-")
+        items.append(yamcs_version)
+        # Format each field with fixed width using ljust and join them into a row string
+        row = "".join(str(item).ljust(w) for item, w in zip(items + [yamcs_version], name_len_list))
+        print(row)
+
+def get_yamcs_version_dict(dir_path, suffix=".txt"):
+    yamcs_version_dict = {}
+    if dir_path.exists():
+        files = sorted(dir_path.glob(f"*{suffix}"), key=lambda f: int(f.stem))
+        for f in files:
+            try:
+                id = int(f.stem)
+                yamcs_version = read_yamcs_version(f)
+                if yamcs_version:
+                    yamcs_version_dict[f"{id}"] = yamcs_version
+                else:
+                    yamcs_version_dict[f"{id}"] = "unknown"
+            except ValueError:
+                continue
+    else:
+        print("Config directory not found. Exiting.", file=sys.stderr)
+        sys.exit(1)
+    return yamcs_version_dict
+
+
+def read_yamcs_version(file_path):
+    with file_path.open(encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("yamcs_version:"):
+                return line.split(":", 1)[1].strip()
+    return None
+
+
+def get_tablespace_names_from_backup_dir(backup_dir):
+    # Get the list of tablespace names directly under backup directory
+    names = [p.name for p in backup_dir.iterdir() if p.is_dir() and p.name != "config"]
+    if not names:
+        print("No backups found.", file=sys.stderr)
+        sys.exit(1)
+    return names

--- a/py/cold_backup.py
+++ b/py/cold_backup.py
@@ -1,0 +1,127 @@
+import argparse
+import subprocess
+import sys
+import requests
+import json
+import re
+from pathlib import Path
+
+from backup_util import fail_exit, check_dir, create_dir, list_backups, get_max_numbered_file
+
+
+def output_config_txt_cold(etc_dir, backup_dir, data_dir):
+    yamcs_version = get_yamcs_version_by_command()
+    config_list = [
+        f"yamcs_version: {yamcs_version}",
+        f"etc_dir: {etc_dir}",
+        f"data_dir: {data_dir}"
+    ]
+    output_dir = backup_dir / "config"
+    last_file_num = get_max_numbered_file(output_dir)
+    file_path = output_dir / f"{last_file_num+1}.txt"
+    with open(file_path, "w") as f:
+        f.writelines('\n'.join(config_list))
+
+
+def get_yamcs_version_by_command():
+    # Get Yamcs version by command
+    result = subprocess.run(
+        ["/opt/yamcs/bin/yamcsd", "-v"], capture_output=True, text=True, check=True
+    )
+    output = result.stdout
+    # Search for 'Yamcs <yamcs_version>'
+    match = re.search(r"^Yamcs (\d+\.\d+\.\d+)\b", output, re.MULTILINE)
+    if match:
+        yamcs_version = match.group(1)
+    else:
+        print("Yamcs version not found.")
+    return yamcs_version
+
+
+def get_tablespace_names_from_data_dir(data_dir):
+    # Get the list of tablespace names directly under data directory
+    names = [p.name for p in data_dir.iterdir() if p.is_dir() and p.name.endswith(".rdb")]
+    if not names:
+        print("No tablespaces found. Exiting.", file=sys.stderr)
+        sys.exit(1)
+    return names
+
+
+def cold_backup_tablespace(etc_dir, backup_dir, data_dir, name):
+    ts_name = name.removesuffix(".rdb")
+    print(f"Tablespace: {ts_name}")
+    cmd = [
+        "/opt/yamcs/bin/yamcsadmin",
+        "--etc-dir", str(etc_dir),
+        "backup", "create",
+        "--backup-dir", str(backup_dir / ts_name),
+        "--data-dir", str(data_dir),
+        ts_name,
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        fail_exit("Backup", ts_name)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Yamcs cold backup script. Use this if Yamcs is not running.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=30),
+        add_help=False
+    )
+    # Required arguments
+    parser.add_argument(
+        "--etc-dir",
+        required=True,
+        help="Path to Yamcs configuration directory.")
+    parser.add_argument(
+        "--backup-dir",
+        required=True,
+        help="Path to directory for backups (auto-created if missing)."
+    )
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        help="Path to a Yamcs data directory."
+    )
+    # Optional arguments
+    parser.add_argument(
+        "-h", "--help",
+        action="help",
+        help="Show this help message and exit."
+    )
+    parser.add_argument(
+        "-l", "--list",
+        action="store_true",
+        help="List available backups instead of creating one."
+    )
+
+    args = parser.parse_args()
+    etc_dir = Path(args.etc_dir)
+    data_dir = Path(args.data_dir)
+    backup_dir = Path(args.backup_dir)
+
+    check_dir(etc_dir)
+    check_dir(data_dir)
+
+    # Print the backups inside the backup directory
+    if args.list:
+        check_dir(backup_dir)
+        list_backups(etc_dir, backup_dir)
+        sys.exit(0)
+
+    # Getting tablespace name
+    names = get_tablespace_names_from_data_dir(data_dir)
+
+    print("Creating backup...")
+    print(f"data: {data_dir}")
+    create_dir(backup_dir)
+    for name in names:
+        cold_backup_tablespace(etc_dir, backup_dir, data_dir, name)
+    output_config_txt_cold(etc_dir, backup_dir, data_dir)
+    print(f"Backup completed! (output: {backup_dir})")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/hot_backup.py
+++ b/py/hot_backup.py
@@ -1,0 +1,146 @@
+import argparse
+import subprocess
+import sys
+import requests
+import json
+from pathlib import Path
+
+from backup_util import fail_exit, check_dir, create_dir, list_backups, get_max_numbered_file
+
+
+def output_config_txt_hot(etc_dir, backup_dir, yamcs_version, pid):
+    if not yamcs_version:
+        yamcs_version = "Unknown"
+    if not pid:
+        yamcs_version = "Unknown"
+    config_list = [
+        f"yamcs_version: {yamcs_version}",
+        f"pid: {pid}",
+        f"etc_dir: {etc_dir}"
+    ]
+    output_dir = backup_dir / "config"
+    last_file_num = get_max_numbered_file(output_dir)
+    file_path = output_dir / f"{last_file_num + 1}.txt"
+    with open(file_path, "w") as f:
+        f.writelines('\n'.join(config_list))
+
+
+def get_yamcs_version_by_api(host_address):
+    # Get Yamcs server version via API
+    api_url = f"http://{host_address}/api/sysinfo"
+    try:
+        resp = requests.get(api_url, timeout=5)
+        resp.raise_for_status()
+        json_data = resp.json()
+    except Exception as e:
+        print(f"Failed to fetch tablespaces from {api_url}: {e}", file=sys.stderr)
+        sys.exit(1)
+    yamcs_version = json_data.get("yamcsVersion", None)
+    if not yamcs_version:
+        print("Could not get yamcs version.", file=sys.stderr)
+    pid = json_data.get("process", None).get("pid", None)
+    if not pid:
+        print("Could not get pid.", file=sys.stderr)
+    return yamcs_version, pid
+
+
+def get_tablespace_names_by_api(host_address):
+    # Get the list of tablespace names via the API
+    api_url = f"http://{host_address}/api/archive/rocksdb/tablespaces"
+    try:
+        resp = requests.get(api_url, timeout=5)
+        resp.raise_for_status()
+        json_data = resp.json()
+    except Exception as e:
+        print(f"Failed to fetch tablespaces from {api_url}: {e}", file=sys.stderr)
+        sys.exit(1)
+    names = [ts["name"] for ts in json_data.get("tablespaces", [])]
+
+    if not names:
+        print("No tablespaces found. Exiting.", file=sys.stderr)
+        sys.exit(1)
+    return names
+
+
+def hot_backup_tablespace(etc_dir, backup_dir, name, pid):
+    print(f"Tablespace: {name}")
+    cmd = [
+        "/opt/yamcs/bin/yamcsadmin",
+        "--etc-dir", str(etc_dir),
+        "backup", "create",
+        "--backup-dir", str(backup_dir / name),
+    ]
+    if pid:
+        cmd.extend(["--pid", pid])
+    cmd.append(name)
+    try:
+        subprocess.run(cmd, check=True)
+        print("Backup performed successfully")
+    except subprocess.CalledProcessError:
+        fail_exit("Backup", name)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Yamcs hot backup script. Use this if Yamcs is running.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=30),
+        add_help=False
+    )
+    # Required arguments
+    parser.add_argument(
+        "--etc-dir",
+        required=True,
+        help="Path to Yamcs configuration directory.")
+    parser.add_argument(
+        "--backup-dir",
+        required=True,
+        help="Path to directory for backups (auto-created if missing)."
+    )
+    # Optional arguments
+    parser.add_argument(
+        "-h", "--help",
+        action="help",
+        help="Show this help message and exit."
+    )
+    parser.add_argument(
+        "-l", "--list",
+        action="store_true",
+        help="List available backups instead of creating one."
+    )
+    parser.add_argument(
+        "--url",
+        metavar="HOST:PORT",
+        default="localhost:8090",
+        help="Host address of Yamcs server (default: localhost:8090)."
+    )
+
+    args = parser.parse_args()
+    etc_dir = Path(args.etc_dir)
+    backup_dir = Path(args.backup_dir)
+    host_address = args.url
+
+    check_dir(etc_dir)
+
+    # Print the backups inside the backup directory
+    if args.list:
+        check_dir(backup_dir)
+        list_backups(etc_dir, backup_dir)
+        sys.exit(0)
+    
+    # Getting system info
+    yamcs_version, pid = get_yamcs_version_by_api(host_address)
+
+    # Getting tablespace name
+    names = get_tablespace_names_by_api(host_address)
+
+    print("Creating backup...")
+    print(f"host address: {host_address}")
+    create_dir(backup_dir)
+    for name in names:
+        hot_backup_tablespace(etc_dir, backup_dir, name, pid)
+    output_config_txt_hot(etc_dir, backup_dir, yamcs_version, pid)
+    print(f"Backup completed! (output: {backup_dir})")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/restore.py
+++ b/py/restore.py
@@ -1,0 +1,157 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from backup_util import fail_exit, check_dir, create_dir, list_backups, get_tablespace_names_from_backup_dir
+
+def delete_backup(etc_dir, backup_dir, names):
+    target_id = get_target_id_from_input(etc_dir, backup_dir, names, "delete")
+    print("Deleting backup...")
+    for name in names:
+        delete_tablespace(etc_dir, backup_dir, name, target_id)
+    delete_config_txt(etc_dir, backup_dir, target_id)
+    print(f"Delete completed! (deleted: {target_id})")
+
+
+def delete_tablespace(etc_dir, backup_dir, name, backup_id):
+    cmd = [
+        "/opt/yamcs/bin/yamcsadmin",
+        "--etc-dir", str(etc_dir),
+        "backup", "delete",
+        "--backup-dir", str(backup_dir / name),
+        str(backup_id),
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        fail_exit("Delete", name)
+
+
+def delete_config_txt(etc_dir, backup_dir, backup_id):
+    file_name = f"{backup_id}.txt"
+    cmd = [
+        "rm", str(backup_dir / "config" / file_name)
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        fail_exit("Delete", "config")
+
+
+def restore_backup(etc_dir, backup_dir, restore_dir, names):
+    target_id = get_target_id_from_input(etc_dir, backup_dir, names, "restore")
+    print("Creating restore...")
+    create_dir(restore_dir)
+    for name in names:
+        restore_tablespace(etc_dir, backup_dir, restore_dir, name, target_id)
+    print(f"Restore completed! (output: {restore_dir})")
+
+
+def restore_tablespace(etc_dir, backup_dir, restore_dir, name, backup_id):
+    cmd = [
+        "/opt/yamcs/bin/yamcsadmin",
+        "--etc-dir", str(etc_dir),
+        "backup", "restore",
+        "--backup-dir", str(backup_dir / name),
+        "--restore-dir", str(restore_dir / f"{name}.rdb"),
+        str(backup_id),
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError:
+        fail_exit("Restore", name)
+
+
+def get_target_id_from_input(etc_dir, backup_dir, names, mode, max_retries=3):
+    for attempt in range(max_retries):
+        list_backups(etc_dir, backup_dir, names=names)
+        try:
+            # Prompt the user to enter the backup ID
+            target_id = int(input(f"Enter the backup ID to {mode} from the list above: "))
+            break
+        except ValueError:
+            # Print error message if input is not a valid integer
+            print(
+                f"Error: Invalid input. Please enter a valid integer ({attempt+1}/{max_retries}).",
+                file=sys.stderr
+            )
+    else:
+        # Exit if the user fails too many times
+        print("Too many invalid attempts. Exiting.", file=sys.stderr)
+        sys.exit(1)
+    return target_id
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Yamcs restore script. Use this if Yamcs is not running.\n"+
+                    "Optionally, the script can list the available backups and delete backups.",
+        formatter_class=lambda prog: argparse.RawTextHelpFormatter(prog, max_help_position=30),
+        add_help=False
+    )
+    # Required arguments
+    parser.add_argument(
+        "--etc-dir",
+        required=True,
+        help="Path to Yamcs configuration directory"
+    )
+    parser.add_argument(
+        "--backup-dir",
+        required=True,
+        help="Path to the source backup directory"
+    )
+    parser.add_argument(
+        "--restore-dir",
+        required=True,
+        help="Path to the directory where backups will be restored"
+    )
+    # Optional arguments
+    parser.add_argument(
+        "-h", "--help",
+        action="help",
+        help="Show this help message and exit."
+    )
+    parser.add_argument(
+        "-l", "--list",
+        action="store_true",
+        help="List available backups instead of creating one."
+    )
+    parser.add_argument(
+        "-d", "--delete",
+        action="store_true",
+        help="Delete one backup from the available backups."
+    )
+
+    args = parser.parse_args()
+    etc_dir = Path(args.etc_dir)
+    backup_dir = Path(args.backup_dir)
+    restore_dir = Path(args.restore_dir)
+
+    check_dir(etc_dir)
+    check_dir(backup_dir)
+
+    # Getting tablespace name
+    names = get_tablespace_names_from_backup_dir(backup_dir)
+    # Print the backups inside the backup directory
+    if args.list:
+        list_backups(etc_dir, backup_dir, names=names)
+        sys.exit(0)
+    
+    # Deletes the backup of the ID entered by the user
+    if args.delete:
+        try:
+            delete_backup(etc_dir, backup_dir, names)
+        except KeyboardInterrupt:
+            print("\nBackup deletion canceled")
+        sys.exit(0)
+
+    # Restore the backup of the ID entered by the user
+    try:
+        restore_backup(etc_dir, backup_dir, restore_dir, names)
+    except KeyboardInterrupt:
+        print("\nBackup restore canceled")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduced a command-line tool to manage Yamcs backups and restores.
- Supports creating hot and cold backups of tablespaces
- Allows restoring from a specified backup ID
- Allows deletion from a specified backup ID
- Provides option to list available backups