### PR TITLE
 tctm: Add allow always and allow time command

### DIFF
--- a/py/tctm/srs3_tc.yaml
+++ b/py/tctm/srs3_tc.yaml
@@ -60,3 +60,24 @@ default_commands:
             type: binary
             bit: 72
             val: 0B01004291BB5990C1
+      - name: "REQ_SET_TX_ALLOW_ALWAYS"
+        port: 19
+        arguments:
+          - name: command_id
+            type: binary
+            bit: 40
+            val: 0B010011E4
+          - name: state
+            type: enum
+            choices:
+              - [0, "false"]
+              - [1, "true"]
+      - name: "REQ_SET_TX_ALLOW_TIME"
+        port: 19
+        arguments:
+          - name: command_id
+            type: binary
+            bit: 40
+            val: 0B010031E5
+          - name: duration_s
+            bit: 16


### PR DESCRIPTION
 It's requied to transmit radio signals only when within
 communication range of a ground station. These commands are
 used to comply with this requirement.
 "allow always" command prevents transmission when set to false.
 When a duration is specified using the "allow time" command,
 SRS-3 can transmmit during that specified period.
 Therefore, when the satellite enters the communication range, the
 gournd station must first send "allow time" command along with
 the duration for the designated pass.