### PR TITLE
Add TC/TM definitions for telemetry history management

### DIFF
--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -226,6 +226,28 @@ default_commands:
           - name: "command_id"
             bit: 8
             val: 0
+      - name: "GET_SYSTEM_HK_HISTORY"
+        port: 15
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "start_seq_no"
+            bit: 32
+          - name: "end_seq_no"
+            bit: 32
+          - name: "skip_count"
+            bit: 16
+          - name: "interval_ms"
+            bit: 16
+      - name: "CANCEL_SYSTEM_HK_HISTORY"
+        port: 15
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 2
       - name: "CLEAR_BOOT_COUNT"
         port: 16
         arguments:
@@ -242,3 +264,9 @@ default_commands:
           - name: "address"
             type: binary
             bit: 32
+      - name: "CLEAR_TLM_SEQ_NUM"
+        port: 16
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 2

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -1103,6 +1103,30 @@ containers:
       - name: "CRC32_OF_LAST_CFG_CRC"
         type: binary
         bit: 32
+  - name: GET_SYSTEM_HK_HISTORY_CMD_REPLY
+    base: "main_container"
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 15
+      - name: "MAIN/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_GET_SYSTEM_HK_HISTORY"
+        signed: true
+        bit: 32
+  - name: CANCEL_SYSTEM_HK_HISTORY_CMD_REPLY
+    base: "main_container"
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 15
+      - name: "MAIN/telemetry_id"
+        val: 2
+    parameters:
+      - name: "ERROR_CODE_OF_CANCEL_SYSTEM_HK_HISTORY"
+        signed: true
+        bit: 32
   - name: CLEAR_BOOT_COUNT_CMD_REPLY
     base: "main_container"
     endian: true
@@ -1140,5 +1164,17 @@ containers:
         val: 255
     parameters:
       - name: "ERROR_CODE_OF_UNKNOWN_CLEAR_BOOT_COUNT"
+        signed: true
+        bit: 32
+  - name: CLEAR_TLM_SEQ_NUM_CMD_REPLY
+    base: "main_container"
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 16
+      - name: "MAIN/telemetry_id"
+        val: 2
+    parameters:
+      - name: "ERROR_CODE_OF_CLEAR_TLM_SEQ_NUM"
         signed: true
         bit: 32


### PR DESCRIPTION
  Update the ground station TC/TM YAML files to support new telemetry history retrieval and management functions.
    
- Add 'GET_SYSTEM_HK_HISTORY' TC definition (Port 15) with arguments for start No, end No, skip count, and transmission interval.
- Add 'CANCEL_SYSTEM_HK_HISTORY' TC definition (Port 15) to interrupt ongoing history downlinks.
- Add 'CLEAR_TLM_SEQ_NUM' TC definition (Port 16) to reset the telemetry sequence counter in FRAM.
- Define corresponding reply TM containers (standard reply format) for all new commands to enable error code tracking on the ground.
