### PR TITLE
tccm: Add command to control magnetorquer and reply telemetry

### DIFF
--- a/py/tctm/main_tc.yaml
+++ b/py/tctm/main_tc.yaml
@@ -22,6 +22,52 @@ default_commands:
         arguments:
           - name: shell_cmd_str
             type: string
+      - name: "MTQ_CTRL_START_CMD"
+        port: 11
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 0
+          - name: "axes"
+            type: enum
+            choices:
+              - [0, "MAIN_X"]
+              - [1, "MAIN_Y"]
+              - [2, "MAIN_Z"]
+              - [3, "BKUP_X"]
+              - [4, "BKUP_Y"]
+              - [5, "BKUP_Z"]
+          - name: "polarity"
+            type: enum
+            choices:
+              - [0, "PLUS"]
+              - [1, "MINUS"]
+              - [2, "NON"]
+          - name: "duty"
+            type: enum
+            choices:
+              - [20, "20"]
+              - [40, "40"]
+              - [60, "60"]
+              - [80, "80"]
+              - [100, "100"]
+      - name: "MTQ_CTRL_STOP_CMD"
+        port: 11
+        endian: true
+        arguments:
+          - name: "command_id"
+            bit: 8
+            val: 1
+          - name: "axes"
+            type: enum
+            choices:
+              - [0, "MAIN_X"]
+              - [1, "MAIN_Y"]
+              - [2, "MAIN_Z"]
+              - [3, "BKUP_X"]
+              - [4, "BKUP_Y"]
+              - [5, "BKUP_Z"]
       - name: "POWER_CONTROL_CMD"
         port: 12
         arguments:

--- a/py/tctm/main_tm.yaml
+++ b/py/tctm/main_tm.yaml
@@ -739,6 +739,30 @@ containers:
         bit: 256
 
 # Command Reply Telemetry
+  - name: MTQ_CONTROL_START_CMD_REPLY
+    base: "main_container"
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 11
+      - name: "MAIN/telemetry_id"
+        val: 0
+    parameters:
+      - name: "ERROR_CODE_OF_MTQ_CONTROL_START"
+        signed: true
+        bit: 32
+  - name: MTQ_CONTROL_STOP_CMD_REPLY
+    base: "main_container"
+    endian: true
+    conditions:
+      - name: "../csp_sport"
+        val: 11
+      - name: "MAIN/telemetry_id"
+        val: 1
+    parameters:
+      - name: "ERROR_CODE_OF_MTQ_CONTROL_STOP"
+        signed: true
+        bit: 32
   - name: POWER_CONTROL_CMD_REPLY
     base: "main_container"
     endian: true


### PR DESCRIPTION
Parameters of start command are as follows:

- Axis: Specifies the target magnetic axis (X, Y, or Z) and corresponding power line
- Polarity: Defines the direction of the magnetic field generated by the magnetorquer
- Duty: Specifies the control intensity (PWM duty cycle) ranging from 20 to 100 (indicates 20% to 100%)