### PR TITLE
java, tctm: Improve EPS file download reliability and update pkt_size

### DIFF
--- a/java/scsat1-packet/src/main/java/Scsat1PacketPreprocessor.java
+++ b/java/scsat1-packet/src/main/java/Scsat1PacketPreprocessor.java
@@ -149,15 +149,13 @@ public class Scsat1PacketPreprocessor extends AbstractPacketPreprocessor {
         private final int sport = 10;
         private final int commandId = 2;
         private final int commandIdOffset = 4;
-        private final int commandIdLength = 1;
         private final int fileIdOffset = 5;
-        private final int fileIdLength = 1;
         private final int blockDataListOffset = 12;
         private final int epsSrcId = 4;
 
         public ExtractEPSFilePacket(TmPacket tmPacket) {
             byte[] packet = tmPacket.getPacket();
-            if (packet.length < fileIdOffset + fileIdLength) {
+            if (packet.length < blockDataListOffset) {
                 header = null;
                 return;
             }
@@ -170,7 +168,6 @@ public class Scsat1PacketPreprocessor extends AbstractPacketPreprocessor {
             }
             int packetSport = cspHeader.getSourcePort();
             int packetCommandId = ByteArrayUtils.decodeUnsignedByte(packet, commandIdOffset);
-            TmPacket tmUpdatePacket = null;
             // If not /SCSAT1/EPS/DATA_PACKET_STREAM, header is null.
             if (sport != packetSport || commandId != packetCommandId ) {
                 header = null;
@@ -197,48 +194,137 @@ public class Scsat1PacketPreprocessor extends AbstractPacketPreprocessor {
             }
         }
 
+        public void dumpHex(byte[] data, int bytesPerLine) {
+            if (data == null) {
+                System.out.println("data is null");
+                return;
+            }
+            for (int i = 0; i < data.length; i++) {
+                System.out.printf("%02X ", data[i]);
+                if ((i + 1) % bytesPerLine == 0) {
+                    System.out.println();
+                }
+            }
+            System.out.println();
+        }
+
+        private void ResetContinuousValue() {
+            extractData = null;
+            payloadLength = -1;
+            expectedEntryId = -1;
+            expectedOffset = 0;
+        }
+
+        // Packet size must be less than the one file size due to only one file can be constructed
         public TmPacket extractedDataFromPacket(TmPacket tmPacket) {
-            UdpTmDataLink udpdata = new UdpTmDataLink();
+            // 1. Basic checks and preparation
+            if (header == null) return tmPacket;
+            
             byte[] packet = tmPacket.getPacket();
-            // Return it as is if the fileID is unexpected or not /SCSAT1/EPS/DATA_PACKET_STREAM
-            if (header == null || packet.length < blockDataListOffset) {
-                return tmPacket;
+            
+            // Constants based on ICD 6.1.8 Data Packet Stream
+            final int ENTRY_ID_OFFSET = 6;
+            final int OFFSET_FIELD_OFFSET = 10;
+            final int ENTRY_HEADER_SIZE = 6;      // CRC(2) + Length(2) + ID(2)
+            final int PAYLOAD_LEN_FIELD_POS = 4;  // Position of 'length' field within the entry header
+            final int ERROR_BLOCK_LEN = 255;      // Error indicator for block length
+        
+            long entryId = ByteArrayUtils.decodeUnsignedIntLE(packet, ENTRY_ID_OFFSET);
+            int offset = ByteArrayUtils.decodeUnsignedShortLE(packet, OFFSET_FIELD_OFFSET);
+        
+            // 2. Check entry continuity and sequence
+            if (shouldResetEntry(entryId, offset)) {
+                ResetContinuousValue();
+                expectedEntryId = entryId;
             }
+        
+            if (offset != expectedOffset) {
+                System.err.printf("[WARN] Offset mismatch for Entry %d. Expected %d, got %d. Discarding.\n", 
+                                  entryId, expectedOffset, offset);
+                ResetContinuousValue();
+                return null;
+            }
+        
+            // 3. Extract and process data blocks from the CSP packet
             byte[] blockDataList = Arrays.copyOfRange(packet, blockDataListOffset, packet.length);
-            int blockStart = 0;
-            TmPacket tmUpdatePacket = null;
-            while (blockStart < blockDataList.length) {
-                int blockLength = ByteArrayUtils.decodeUnsignedByte(blockDataList, blockStart);
-                if (blockLength == 255) {
-                    // If block_len = 255 - field "err" contains error code
-                    blockStart += 2;
-                    tmUpdatePacket = tmPacket;
+            int cursor = 0;
+            TmPacket resultPacket = null;
+        
+            while (cursor < blockDataList.length) {
+                int blockLen = ByteArrayUtils.decodeUnsignedByte(blockDataList, cursor);
+                
+                // Handle ICD specific error condition (block_len = 0xFF)
+                if (blockLen == ERROR_BLOCK_LEN) {
+                    System.err.println("[ERROR] Received 0xFF block length (EPS Error condition).");
+                    ResetContinuousValue();
+                    return null;
                 }
-                if (extractData == null) {
-                    // Start of the extracted data
-                    if (blockStart + 5 > blockDataList.length) {
-                        return tmPacket;
-                    }
-                    extractDataLength = ByteArrayUtils.decodeUnsignedShortLE(blockDataList, blockStart + 5);
-                    extractData = Arrays.copyOfRange(blockDataList, blockStart + 7, blockStart + blockLength + 1);
-                } else {
-                    // Continuation of the extracted data
-                    byte[] newExtractData = new byte[extractData.length + blockLength];
-                    System.arraycopy(extractData, 0, newExtractData, 0, extractData.length);
-                    System.arraycopy(blockDataList, blockStart + 1, newExtractData, extractData.length, blockLength);
-                    extractData = newExtractData;
+        
+                // Safety check for array boundaries
+                if (cursor + 1 + blockLen > blockDataList.length) {
+                    System.err.println("[ERROR] Block length exceeds packet size boundaries.");
+                    ResetContinuousValue();
+                    return null;
                 }
-                if (extractData.length >= extractDataLength) {
-                    // Return the packet once the data is complete
-                    byte[] newPacketData = new byte[header.length + extractData.length];
-                    System.arraycopy(header, 0, newPacketData, 0, header.length);
-                    System.arraycopy(extractData, 0, newPacketData, header.length, extractData.length);
-                    tmUpdatePacket = new TmPacket(tmPacket.getReceptionTime(), newPacketData);
-                    extractData = null;
+        
+                // Accumulate data into the buffer
+                byte[] block = Arrays.copyOfRange(blockDataList, cursor + 1, cursor + 1 + blockLen);
+                appendExtractedData(block);
+                
+                cursor += 1 + blockLen;
+                expectedOffset += blockLen;
+        
+                // 4. Completion check and decoding
+                // Extract payload length once enough bytes are accumulated for the entry header
+                if (payloadLength == -1 && extractData.length >= ENTRY_HEADER_SIZE) {
+                    payloadLength = ByteArrayUtils.decodeUnsignedShortLE(extractData, PAYLOAD_LEN_FIELD_POS);
                 }
-                blockStart = blockStart + blockLength + 1;
+        
+                // BUG FIX: Ensure payloadLength is valid (!= -1) before performing size checks
+                // to prevent IllegalArgumentException when extractData.length is small.
+                if (payloadLength != -1 && extractData.length >= (payloadLength + ENTRY_HEADER_SIZE)) {
+                    resultPacket = createYamcsPacket(tmPacket);
+                    
+                    // Prepare for the next entry (handles multiple entries within a single CSP packet)
+                    ResetContinuousValue(); 
+                    expectedEntryId = entryId + 1; // Anticipate next sequence ID
+                    expectedOffset = 0;
+                }
             }
-            return tmUpdatePacket;
+        
+            return resultPacket;
+        }
+        
+        // Helper to determine if the current entry process should be reset.
+        private boolean shouldResetEntry(long entryId, int offset) {
+            return (expectedEntryId == -1) || (entryId != expectedEntryId) || (offset == 0);
+        }
+        
+        // Appends the new data block to the existing extraction buffer.
+        private void appendExtractedData(byte[] block) {
+            if (extractData == null) {
+                extractData = block;
+            } else {
+                byte[] merged = new byte[extractData.length + block.length];
+                System.arraycopy(extractData, 0, merged, 0, extractData.length);
+                System.arraycopy(block, 0, merged, extractData.length, block.length);
+                extractData = merged;
+            }
+        }
+        
+        // Generates a Yamcs TmPacket from the successfully reassembled entry data.
+        private TmPacket createYamcsPacket(TmPacket original) {
+            final int ENTRY_HEADER_SIZE = 6;
+            // Extract only the payload portion (excluding the 6-byte entry header)
+            byte[] payload = Arrays.copyOfRange(extractData, ENTRY_HEADER_SIZE, ENTRY_HEADER_SIZE + payloadLength);
+            
+            // Combine Yamcs header and the extracted payload
+            byte[] newPacketData = new byte[header.length + payload.length];
+            System.arraycopy(header, 0, newPacketData, 0, header.length);
+            System.arraycopy(payload, 0, newPacketData, header.length, payload.length);
+            
+            System.out.printf("[INFO] Entry reconstruction complete. Created packet size: %d\n", newPacketData.length);
+            return new TmPacket(original.getReceptionTime(), newPacketData);
         }
     }
 
@@ -273,8 +359,10 @@ public class Scsat1PacketPreprocessor extends AbstractPacketPreprocessor {
     }
 
     private byte[] extractData = null;
-    private int  extractDataLength;
-    
+    private int  payloadLength = -1;
+    private long expectedEntryId = -1;
+    private int expectedOffset = 0;
+
     public TmPacket extractPacket(TmPacket tmPacket) {
         ExtractEPSFilePacket extractedParamData = new ExtractEPSFilePacket(tmPacket);
         return extractedParamData.extractedDataFromPacket(tmPacket);

--- a/py/tctm/eps_tc.yaml
+++ b/py/tctm/eps_tc.yaml
@@ -241,7 +241,7 @@ default_commands:
             val: 120
           - name: pkt_size
             bit: 16
-            val: 248
+            val: 244
       - name: "REQ_FILE_DOWNLOAD"
         port: 10
         endian: true


### PR DESCRIPTION
- Implemented Entry ID/Offset continuity checks for robust packet reassembly.
- Fixed potential exceptions during payload length validation.
- Reduced default `pkt_size` to 244 to comply with CSP packet size limits.